### PR TITLE
Support OpenAI-compatible endpoints via OPENAI_BASE_URL

### DIFF
--- a/Detection/README.md
+++ b/Detection/README.md
@@ -36,6 +36,17 @@ export OPENAI_API_KEY="your_key"      # For OpenAI triage LLM
 export HF_TOKEN="your_token"          # For Hugging Face models (optional)
 ```
 
+**OpenAI-compatible endpoints (optional):**
+
+Set `OPENAI_BASE_URL` to point the triage LLM at any OpenAI-compatible API. For example, to use [Abliteration.ai](https://docs.abliteration.ai):
+
+```bash
+export OPENAI_BASE_URL="https://api.abliteration.ai/v1"
+export OPENAI_API_KEY="$ABLIT_KEY"
+```
+
+Then set the triage model in `config_detector.yaml` to a model the endpoint serves (e.g. `abliterated-model`).
+
 **Models Used:**
 
 - Triage: `gpt-4o`

--- a/Detection/openai_config.py
+++ b/Detection/openai_config.py
@@ -30,9 +30,15 @@ def get_openai_client() -> OpenAI:
     Get a configured OpenAI client using OPENAI_API_KEY environment variable.
     All ads_platform components should use this function to get their OpenAI client.
 
+    Set the OPENAI_BASE_URL environment variable to point the client at any
+    OpenAI-compatible API endpoint (passed to the SDK as base_url).
+
     Returns:
         OpenAI: Configured client
     """
+    base_url = os.environ.get("OPENAI_BASE_URL")
+    if base_url:
+        return OpenAI(api_key=os.environ["OPENAI_API_KEY"], base_url=base_url)
     return OpenAI(api_key=os.environ["OPENAI_API_KEY"])
 
 
@@ -41,11 +47,15 @@ def get_openai_config() -> Dict[str, Any]:
     Get the OpenAI configuration dictionary.
 
     Returns:
-        Dict containing api_key
+        Dict containing api_key, and base_url when OPENAI_BASE_URL is set
     """
-    return {
+    config = {
         'api_key': os.environ["OPENAI_API_KEY"],
     }
+    base_url = os.environ.get("OPENAI_BASE_URL")
+    if base_url:
+        config['base_url'] = base_url
+    return config
 
 
 def create_chat_completion(

--- a/Detection/tests/test_openai_config.py
+++ b/Detection/tests/test_openai_config.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from openai_config import calculate_cost
+from openai_config import calculate_cost, get_openai_client, get_openai_config
 
 
 class TestCalculateCost:
@@ -20,3 +20,31 @@ class TestCalculateCost:
         cost = calculate_cost(3.00, 15.00, 500_000, 200_000)
         expected = (500_000 * 3.00 + 200_000 * 15.00) / 1_000_000
         assert cost == pytest.approx(expected)
+
+
+class TestGetOpenaiClient:
+    def test_default_base_url(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        client = get_openai_client()
+        assert str(client.base_url) == "https://api.openai.com/v1/"
+
+    def test_custom_base_url(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://llm.example.com/v1")
+        client = get_openai_client()
+        assert str(client.base_url) == "https://llm.example.com/v1/"
+
+
+class TestGetOpenaiConfig:
+    def test_no_base_url_by_default(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        config = get_openai_config()
+        assert config == {"api_key": "test-key"}
+
+    def test_includes_base_url_when_set(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://llm.example.com/v1")
+        config = get_openai_config()
+        assert config["base_url"] == "https://llm.example.com/v1"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

**Related issue**: N/A

**What changed?**

`Detection/openai_config.py` — the single place where OpenAI clients are constructed — now reads the optional `OPENAI_BASE_URL` environment variable:

- `get_openai_client()` passes it to the SDK as `base_url` when set, so every consumer (`create_chat_completion`, `create_reasoning_completion`, the ADR baseline agent) can be pointed at any OpenAI-compatible API.
- `get_openai_config()` includes a `base_url` key when the variable is set.
- When `OPENAI_BASE_URL` is unset, behavior is byte-for-byte identical to before (default `api.openai.com` endpoint).

Also adds unit tests for both helpers (`Detection/tests/test_openai_config.py`) and a short README section documenting the option with a provider example (Abliteration.ai).

**Why?**

The triage model is configurable in `config_detector.yaml`, but the client was hardcoded to the hosted OpenAI API. Teams running OpenAI-compatible gateways or alternate providers (self-hosted vLLM, LiteLLM proxies, etc.) had no way to route detector traffic there. `OPENAI_BASE_URL` follows the OpenAI SDK's own convention, so it's the least surprising knob.

**How did you test it?**

- `uv run pytest tests/test_openai_config.py` — 8 passed (4 existing + 4 new covering default endpoint, custom base URL, and the config dict with/without `OPENAI_BASE_URL`).
- `black --check` clean on the touched test file; `openai_config.py` keeps the file's existing style.
- Verified no new flake8 findings in the touched code (the file's pre-existing warnings are untouched).

**Potential risks**

None expected: the new code path only activates when `OPENAI_BASE_URL` is set; existing deployments without it are unaffected. The Anthropic/Claude path is untouched.