### PR TITLE
fix(sensor): bound WarpParser to a recent-conversation window

### DIFF
--- a/Sensor/adr_sensor/observer.py
+++ b/Sensor/adr_sensor/observer.py
@@ -54,7 +54,7 @@ class AgentObserver:
         )
         self.codex_parser = CodexParser()
         self.cline_parser = ClineParser()
-        self.warp_parser = WarpParser()
+        self.warp_parser = WarpParser(max_age_days=max_age_days) if max_age_days is not None else WarpParser()
 
         self.output_dir = output_dir if output_dir else Path("output")
         self.output_dir.mkdir(exist_ok=True)

--- a/Sensor/adr_sensor/parsers/warp_parser.py
+++ b/Sensor/adr_sensor/parsers/warp_parser.py
@@ -3,11 +3,14 @@ Parser for Warp Terminal logs.
 Reads SQLite database from the Warp application data directory.
 
 Supports macOS path. Linux support can be added when Warp provides Linux paths.
+
+Performance-optimized: Skips conversations older than 2 weeks by default.
 """
 
 import json
 import sqlite3
 import traceback
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -15,13 +18,16 @@ from ..schemas.agent_event_schema import AgentEvent, ChatMessage, ToolUsage
 from ..utils.timestamp_utils import normalize_timestamp
 from .base_parser import BaseParser
 
+MAX_CONVERSATION_AGE_DAYS = 14
+
 
 class WarpParser(BaseParser):
     """Parser for Warp Terminal SQLite database."""
 
-    def __init__(self):
+    def __init__(self, max_age_days: int = MAX_CONVERSATION_AGE_DAYS):
         self.base_path = Path.home() / "Library/Application Support/dev.warp.Warp-Stable"
         self.db_path = self.base_path / "warp.sqlite"
+        self.max_age_days = max_age_days
 
     def parse_all(self) -> List[AgentEvent]:
         """Parse all available Warp Terminal logs."""
@@ -42,7 +48,12 @@ class WarpParser(BaseParser):
             conversations = self._get_all_conversations(conn)
             print(f"[WARP] Found {len(conversations)} conversations")
 
-            for conversation in conversations:
+            recent_conversations = self._filter_recent_conversations(conversations)
+            skipped_count = len(conversations) - len(recent_conversations)
+            if skipped_count > 0:
+                print(f"[WARP] Skipped {skipped_count} conversations older than {self.max_age_days} days")
+
+            for conversation in recent_conversations:
                 conversation_id = conversation["conversation_id"]
                 try:
                     exchanges = self._get_conversation_exchanges(conn, conversation_id)
@@ -61,14 +72,42 @@ class WarpParser(BaseParser):
         return entries
 
     def _get_all_conversations(self, conn) -> List[Dict]:
-        """Get all conversations from the database."""
+        """Get all conversation ids and timestamps from the database.
+
+        Deliberately excludes the conversation_data column: it is not used
+        anywhere in this parser (exchange content comes from ai_queries /
+        ai_blocks instead), so fetching it here would be wasted I/O for
+        every conversation on every run.
+        """
         cursor = conn.cursor()
         cursor.execute("""
-            SELECT conversation_id, conversation_data, last_modified_at
+            SELECT conversation_id, last_modified_at
             FROM agent_conversations
             ORDER BY last_modified_at DESC
         """)
         return [dict(row) for row in cursor.fetchall()]
+
+    def _filter_recent_conversations(self, conversations: List[Dict]) -> List[Dict]:
+        """Filter out conversations whose last_modified_at is older than max_age_days.
+
+        A conversation with a missing or unparseable timestamp is kept rather than
+        dropped, since we can't determine its age.
+        """
+        cutoff_time = datetime.now(timezone.utc) - timedelta(days=self.max_age_days)
+        recent = []
+        for conversation in conversations:
+            last_modified = conversation.get("last_modified_at")
+            conv_timestamp = None
+            if last_modified is not None:
+                try:
+                    conv_timestamp = normalize_timestamp(last_modified)
+                except Exception:
+                    pass
+
+            if conv_timestamp is None or conv_timestamp >= cutoff_time:
+                recent.append(conversation)
+
+        return recent
 
     def _get_conversation_exchanges(self, conn, conversation_id: str) -> List[Dict]:
         """Get all exchanges for a conversation with LLM output."""

--- a/Sensor/tests/test_parsers.py
+++ b/Sensor/tests/test_parsers.py
@@ -1,8 +1,9 @@
 """Tests for ADR Sensor parsers."""
 
 import json
+import sqlite3
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,6 +12,7 @@ import pytest
 from adr_sensor.parsers.claude_parser import ClaudeParser
 from adr_sensor.parsers.cline_parser import ClineParser
 from adr_sensor.parsers.codex_parser import CodexParser
+from adr_sensor.parsers.warp_parser import WarpParser
 
 
 class TestClaudeParser:
@@ -211,3 +213,178 @@ class TestCodexParser:
         parser.base_path = Path("/nonexistent/path")
         entries = parser.parse_all()
         assert entries == []
+
+
+def _build_warp_db(db_path: Path, conversations: list) -> None:
+    """Create a synthetic warp.sqlite matching the schema WarpParser queries.
+
+    Each item in `conversations` is a dict with keys:
+        conversation_id, last_modified_at, exchanges
+    where `exchanges` is a list of (exchange_id, start_ts, input_json, llm_output_json).
+    """
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE agent_conversations (
+            conversation_id TEXT PRIMARY KEY,
+            conversation_data TEXT,
+            last_modified_at TEXT
+        )
+        """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE ai_queries (
+            exchange_id TEXT,
+            conversation_id TEXT,
+            start_ts TEXT,
+            input TEXT,
+            working_directory TEXT,
+            output_status TEXT,
+            model_id TEXT
+        )
+        """
+    )
+    cursor.execute("CREATE TABLE ai_blocks (exchange_id TEXT, output TEXT)")
+
+    for conv in conversations:
+        cursor.execute(
+            "INSERT INTO agent_conversations VALUES (?, ?, ?)",
+            (conv["conversation_id"], "unused_blob", conv["last_modified_at"]),
+        )
+        for exchange_id, start_ts, input_json, llm_output_json in conv.get("exchanges", []):
+            cursor.execute(
+                "INSERT INTO ai_queries VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (exchange_id, conv["conversation_id"], start_ts, input_json, "/tmp/project", "success", "claude"),
+            )
+            if llm_output_json is not None:
+                cursor.execute("INSERT INTO ai_blocks VALUES (?, ?)", (exchange_id, llm_output_json))
+
+    conn.commit()
+    conn.close()
+
+
+class TestWarpParser:
+    def _make_parser(self, tmp_path: Path, max_age_days: int = 14) -> WarpParser:
+        parser = WarpParser(max_age_days=max_age_days)
+        parser.base_path = tmp_path
+        parser.db_path = tmp_path / "warp.sqlite"
+        return parser
+
+    def _query_exchange(self, exchange_id: str, timestamp: str) -> tuple:
+        input_json = json.dumps([{"Query": {"text": f"hello from {exchange_id}"}}])
+        llm_output_json = json.dumps({"Received": {"output": [{"Text": {"text": f"reply for {exchange_id}"}}]}})
+        return (exchange_id, timestamp, input_json, llm_output_json)
+
+    def test_skips_conversations_older_than_max_age(self, tmp_path):
+        """Old conversations should be filtered out before the expensive per-conversation query runs."""
+        now = datetime.now(timezone.utc)
+        recent_ts = now.isoformat()
+        old_ts = (now - timedelta(days=30)).isoformat()
+
+        conversations = [
+            {
+                "conversation_id": "recent-conv",
+                "last_modified_at": recent_ts,
+                "exchanges": [self._query_exchange("ex-recent", recent_ts)],
+            },
+            {
+                "conversation_id": "old-conv",
+                "last_modified_at": old_ts,
+                "exchanges": [self._query_exchange("ex-old", old_ts)],
+            },
+        ]
+        db_path = tmp_path / "warp.sqlite"
+        _build_warp_db(db_path, conversations)
+
+        parser = self._make_parser(tmp_path, max_age_days=14)
+        entries = parser.parse_all()
+
+        session_ids = {e.session_id for e in entries}
+        assert "warp_recent-conv" in session_ids
+        assert "warp_old-conv" not in session_ids
+
+    def test_all_history_via_large_max_age_days(self, tmp_path):
+        """A larger max_age_days should include conversations that would otherwise be skipped."""
+        now = datetime.now(timezone.utc)
+        old_ts = (now - timedelta(days=30)).isoformat()
+
+        conversations = [
+            {
+                "conversation_id": "old-conv",
+                "last_modified_at": old_ts,
+                "exchanges": [self._query_exchange("ex-old", old_ts)],
+            }
+        ]
+        db_path = tmp_path / "warp.sqlite"
+        _build_warp_db(db_path, conversations)
+
+        parser = self._make_parser(tmp_path, max_age_days=10000)
+        entries = parser.parse_all()
+
+        assert {e.session_id for e in entries} == {"warp_old-conv"}
+
+    def test_parses_conversation_content(self, tmp_path):
+        """Recent conversations should still be parsed into chat history correctly."""
+        now = datetime.now(timezone.utc)
+        ts1 = now.isoformat()
+        ts2 = (now + timedelta(seconds=1)).isoformat()
+
+        action_result_input = json.dumps(
+            [
+                {
+                    "ActionResult": {
+                        "id": "tool-1",
+                        "result": {
+                            "RequestCommandOutput": {
+                                "result": {"Success": {"command": "ls", "output": "file.txt", "exit_code": 0}}
+                            }
+                        },
+                    }
+                }
+            ]
+        )
+
+        conversations = [
+            {
+                "conversation_id": "conv-1",
+                "last_modified_at": ts2,
+                "exchanges": [
+                    self._query_exchange("ex-1", ts1),
+                    ("ex-2", ts2, action_result_input, None),
+                ],
+            }
+        ]
+        db_path = tmp_path / "warp.sqlite"
+        _build_warp_db(db_path, conversations)
+
+        parser = self._make_parser(tmp_path)
+        entries = parser.parse_all()
+
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.source == "warp"
+        assert entry.session_id == "warp_conv-1"
+        assert len(entry.chat_history) == 2
+
+        user_msg = entry.chat_history[0]
+        assert user_msg.role == "user"
+        assert "hello from ex-1" in user_msg.content
+
+        assistant_msg = entry.chat_history[1]
+        assert assistant_msg.role == "assistant"
+        assert len(assistant_msg.tools) == 1
+        assert assistant_msg.tools[0].tool_name == "execute_command"
+        assert assistant_msg.tools[0].status == "success"
+
+    def test_parse_all_no_database(self, tmp_path):
+        """Test parse_all when the database file doesn't exist."""
+        parser = self._make_parser(tmp_path)
+        entries = parser.parse_all()
+        assert entries == []
+
+    def test_default_max_age_days(self):
+        """Constructor should default to the module-level constant when unset."""
+        parser = WarpParser()
+        assert parser.max_age_days == 14


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**Related issue**: Closes #17

**What changed?**
`WarpParser` now takes a `max_age_days` parameter (default 14, matching `MAX_CONVERSATION_AGE_DAYS` used elsewhere) and filters conversations by `last_modified_at` before running the per-conversation exchange query, mirroring the existing pattern in `CursorParser`. The conversation-listing query also drops the unused `conversation_data` column. `AgentObserver` now threads `max_age_days` through to `WarpParser` the same way it already does for `ClaudeParser`/`CursorParser`/`ClaudeDesktopParser`, so `--all-history` applies consistently across all SQLite/JSONL-backed sources instead of silently skipping Warp.

**Why?**
Warp conversation history in `warp.sqlite` grows unboundedly with normal usage, and the sensor is expected to run repeatedly (cron/launchd) on end-user machines. Without an age cutoff, every run re-scanned the full `agent_conversations` table and issued a separate SQL JOIN per conversation ever recorded — cost that only grows over time. `ClaudeParser`, `CursorParser`, and `ClaudeDesktopParser` already solve this with an identical `max_age_days` cutoff pattern; `WarpParser` was the one SQLite-backed parser missing it.

**How did you test it?**
Added `TestWarpParser` to `tests/test_parsers.py` (previously no coverage existed for this parser) against a synthetic SQLite DB matching the real schema (`agent_conversations`, `ai_queries`, `ai_blocks`): verifies old conversations are excluded, a larger `max_age_days` override includes them again, conversation content (user query + assistant tool-use message) still parses correctly, and empty-DB/default-constant behavior.

Ran the full existing suite locally with `pytest tests/ -v`:

<details>
<summary>64 passed, 1 warning (pre-existing, unrelated to this change) — click to expand</summary>

```
============================= test session starts ==============================
platform darwin -- Python 3.14.0, pytest-9.1.1, pluggy-1.6.0 -- /private/tmp/adr_sensor_venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/test4/Desktop/OSS/Uber ADR/Sensor
configfile: pyproject.toml
collecting ... collected 64 items

tests/test_cli.py::test_cli_version_matches_package_metadata PASSED      [  1%]
tests/test_observer.py::TestAgentObserver::test_init_default PASSED      [  3%]
tests/test_observer.py::TestAgentObserver::test_display_summary_empty PASSED [  4%]
tests/test_observer.py::TestAgentObserver::test_display_summary_with_entries PASSED [  6%]
tests/test_observer.py::TestAgentObserver::test_save_to_file_json PASSED [  7%]
tests/test_observer.py::TestAgentObserver::test_save_to_file_jsonl PASSED [  9%]
tests/test_observer.py::TestAgentObserver::test_save_sessions_individual PASSED [ 10%]
tests/test_observer.py::TestAgentObserver::test_clean_filename PASSED    [ 12%]
tests/test_observer.py::TestAgentObserver::test_filter_entries_by_existing_files PASSED [ 14%]
tests/test_observer.py::TestAgentObserver::test_ingest_all_handles_parser_errors PASSED [ 15%]
tests/test_parsers.py::TestClaudeParser::test_parse_jsonl_file PASSED    [ 17%]
tests/test_parsers.py::TestClaudeParser::test_parse_empty_file PASSED    [ 18%]
tests/test_parsers.py::TestClaudeParser::test_parse_all_no_directory PASSED [ 20%]
tests/test_parsers.py::TestClaudeParser::test_truncate_large_arguments PASSED [ 21%]
tests/test_parsers.py::TestClineParser::test_parse_cline_log PASSED      [ 23%]
tests/test_parsers.py::TestClineParser::test_extract_mcp_tools PASSED    [ 25%]
tests/test_parsers.py::TestClineParser::test_parse_no_directory PASSED   [ 26%]
tests/test_parsers.py::TestCodexParser::test_parse_jsonl_file PASSED     [ 28%]
tests/test_parsers.py::TestCodexParser::test_parse_no_directory PASSED   [ 29%]
tests/test_parsers.py::TestWarpParser::test_skips_conversations_older_than_max_age PASSED [ 31%]
tests/test_parsers.py::TestWarpParser::test_all_history_via_large_max_age_days PASSED [ 32%]
tests/test_parsers.py::TestWarpParser::test_parses_conversation_content PASSED [ 34%]
tests/test_parsers.py::TestWarpParser::test_parse_all_no_database PASSED [ 35%]
tests/test_parsers.py::TestWarpParser::test_default_max_age_days PASSED  [ 37%]
tests/test_schemas.py::TestToolUsage::test_create_basic PASSED           [ 39%]
tests/test_schemas.py::TestToolUsage::test_create_with_all_fields PASSED [ 40%]
tests/test_schemas.py::TestToolUsage::test_frozen PASSED                 [ 42%]
tests/test_schemas.py::TestChatMessage::test_create_user_message PASSED  [ 43%]
tests/test_schemas.py::TestChatMessage::test_create_assistant_message_with_tools PASSED [ 45%]
tests/test_schemas.py::TestAgentEvent::test_create_basic PASSED          [ 46%]
tests/test_schemas.py::TestAgentEvent::test_uuid_deterministic PASSED    [ 48%]
tests/test_schemas.py::TestAgentEvent::test_uuid_unique_for_different_sessions PASSED [ 50%]
tests/test_schemas.py::TestAgentEvent::test_has_meaningful_content_empty PASSED [ 51%]
tests/test_schemas.py::TestAgentEvent::test_has_meaningful_content_single_error PASSED [ 53%]
tests/test_schemas.py::TestAgentEvent::test_has_meaningful_content_real_conversation PASSED [ 54%]
tests/test_schemas.py::TestAgentEvent::test_has_meaningful_content_with_tools PASSED [ 56%]
tests/test_schemas.py::TestAgentEvent::test_has_tool_usage PASSED        [ 57%]
tests/test_schemas.py::TestAgentEvent::test_to_dict PASSED               [ 59%]
tests/test_schemas.py::TestAgentEvent::test_to_json PASSED               [ 60%]
tests/test_schemas.py::TestAgentEvent::test_get_summary PASSED           [ 62%]
tests/test_schemas.py::TestAgentEvent::test_get_content_hash PASSED      [ 64%]
tests/test_schemas.py::TestAgentEvent::test_get_non_null_fields PASSED   [ 65%]
tests/test_schemas.py::TestAgentEvent::test_auto_populates_hostname_username PASSED [ 67%]
tests/test_utils.py::TestTruncateMiddle::test_short_string_unchanged PASSED [ 68%]
tests/test_utils.py::TestTruncateMiddle::test_empty_string PASSED        [ 70%]
tests/test_utils.py::TestTruncateMiddle::test_none_string PASSED         [ 71%]
tests/test_utils.py::TestTruncateMiddle::test_exact_length_unchanged PASSED [ 73%]
tests/test_utils.py::TestTruncateMiddle::test_truncation PASSED          [ 75%]
tests/test_utils.py::TestTruncateMiddle::test_custom_edge_chars PASSED   [ 76%]
tests/test_utils.py::TestNormalizeTimestamp::test_iso_string PASSED      [ 78%]
tests/test_utils.py::TestNormalizeTimestamp::test_iso_string_with_offset PASSED [ 79%]
tests/test_utils.py::TestNormalizeTimestamp::test_unix_timestamp_seconds PASSED [ 81%]
tests/test_utils.py::TestNormalizeTimestamp::test_unix_timestamp_milliseconds PASSED [ 82%]
tests/test_utils.py::TestNormalizeTimestamp::test_datetime_naive PASSED  [ 84%]
tests/test_utils.py::TestNormalizeTimestamp::test_datetime_aware PASSED  [ 85%]
tests/test_utils.py::TestNormalizeTimestamp::test_string_unix_timestamp PASSED [ 87%]
tests/test_utils.py::TestNormalizeTimestamp::test_invalid_string PASSED  [ 89%]
tests/test_utils.py::TestNormalizeTimestamp::test_invalid_type PASSED    [ 90%]
tests/test_utils.py::TestNormalizeTimestamp::test_float_timestamp PASSED [ 92%]
tests/test_utils.py::TestFormatTimestampForFilename::test_format PASSED  [ 93%]
tests/test_utils.py::TestParseTimestampFromFilename::test_valid_filename PASSED [ 95%]
tests/test_utils.py::TestParseTimestampFromFilename::test_invalid_filename PASSED [ 96%]
tests/test_utils.py::TestParseTimestampFromFilename::test_none_filename PASSED [ 98%]
tests/test_utils.py::TestParseTimestampFromFilename::test_malformed_timestamp PASSED [100%]

=============================== warnings summary ===============================
tests/test_observer.py::TestAgentObserver::test_ingest_all_handles_parser_errors
  /Users/test4/Desktop/OSS/Uber ADR/Sensor/adr_sensor/observer.py:66: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "timestamp": datetime.utcnow().isoformat(timespec="milliseconds") + "Z",

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 64 passed, 1 warning in 0.10s =========================
```
</details>

**Potential risks**
Low. The filtering logic is a direct mirror of `CursorParser`'s already-shipped behavior. The only behavior change for existing users: conversations older than 14 days are no longer re-ingested by default — same tradeoff already accepted for Claude/Cursor/Claude Desktop, and overridable via `max_age_days`/`--all-history`.
