### PR TITLE
fix: add Windows path support for CursorParser and ClineParser

### DIFF
--- a/Sensor/adr_sensor/parsers/cline_parser.py
+++ b/Sensor/adr_sensor/parsers/cline_parser.py
@@ -6,6 +6,7 @@ Supports both macOS and Linux paths.
 """
 
 import json
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -20,7 +21,7 @@ class ClineParser(BaseParser):
     """Parser for Cline (Claude Dev) logs."""
 
     def __init__(self):
-        # Support macOS and Linux paths
+        # Support macOS, Linux, and Windows paths
         macos_path = (
             Path.home()
             / "Library/Application Support/Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks"
@@ -28,7 +29,17 @@ class ClineParser(BaseParser):
         linux_path = (
             Path.home() / ".config/Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks"
         )
-        self.base_path = macos_path if macos_path.exists() else linux_path
+        windows_path = (
+            Path(os.getenv("APPDATA", Path.home() / "AppData/Roaming")) 
+            / "Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks"
+        )
+        
+        if macos_path.exists():
+            self.base_path = macos_path
+        elif windows_path.exists():
+            self.base_path = windows_path
+        else:
+            self.base_path = linux_path
 
     def parse_all(self) -> List[AgentEvent]:
         """Parse all available Cline logs."""

--- a/Sensor/adr_sensor/parsers/cursor_parser.py
+++ b/Sensor/adr_sensor/parsers/cursor_parser.py
@@ -8,6 +8,7 @@ Performance-optimized: Skips conversations older than 2 weeks.
 """
 
 import json
+import os
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -26,11 +27,15 @@ class CursorParser(BaseParser):
     """Parser for Cursor SQLite database logs."""
 
     def __init__(self, max_age_days: int = MAX_CONVERSATION_AGE_DAYS):
-        # Support macOS and Linux paths
+        # Support macOS, Linux, and Windows paths
         macos_path = Path.home() / "Library/Application Support/Cursor/User/globalStorage/state.vscdb"
         linux_path = Path.home() / ".config/Cursor/User/globalStorage/state.vscdb"
+        windows_path = Path(os.getenv("APPDATA", Path.home() / "AppData/Roaming")) / "Cursor/User/globalStorage/state.vscdb"
+        
         if macos_path.exists():
             self.db_path = macos_path
+        elif windows_path.exists():
+            self.db_path = windows_path
         else:
             self.db_path = linux_path
         self.max_age_days = max_age_days


### PR DESCRIPTION
**What changed?**
    Added Windows path support for `CursorParser` and `ClineParser`.
    - Imported the `os` module in both parser files.
    - Used `os.getenv("APPDATA")` with a fallback to `~/AppData/Roaming` to locate the `%APPDATA%` directory
  dynamically on Windows machines.
    - Added `windows_path` configuration strings matching the target application data stores for both Cursor and
  Cline.
    - Incorporated the `windows_path` directory check into the main parser `__init__` resolution chains.

    <!-- Tell your future self why have you made these changes -->
    **Why?**
    Previously, `CursorParser` and `ClineParser` relied solely on hardcoded macOS and Linux configurations to
  discover log paths (`~/.config` and `~/Library/Application Support/`). This caused the tool to silently fail and
  report zero telemetry on Windows.

    <!-- How have you verified this change? Tested locally? Added a unit test? Checked in a staging env? -->
    **How did you test it?**
    Tested locally to ensure existing fallback chains correctly identify the local machine's OS path. Existing test
  suite checks for missing directories continue to pass as expected.

    <!-- Assuming the worst case, what can be broken when deploying this change to production? -->
    **Potential risks**
    Minimal risk. The path checks (`exists()`) safely fail over through macOS -> Windows -> Linux. This change is
  purely additive and does not modify the telemetry parsing logic itself, so it shouldn't disrupt existing telemetry
  capabilities on non-Windows environments.