### PR TITLE
fix(sensor): add Windows path support to CursorParser and ClineParser

### DIFF
--- a/Sensor/README.md
+++ b/Sensor/README.md
@@ -10,14 +10,14 @@ ADR Sensor is a Python library that collects telemetry from AI coding agents to 
 ## Supported AI Agents
 
 
-| Agent                         | Log Format                    | Platform     |
-| ----------------------------- | ----------------------------- | ------------ |
-| **Claude Code**               | JSONL (`~/.claude/projects/`) | macOS, Linux |
-| **Cursor IDE**                | SQLite (`state.vscdb`)        | macOS, Linux |
-| **Cline (Claude Dev)**        | JSON task files               | macOS, Linux |
-| **Claude Desktop Agent Mode** | JSONL audit logs              | macOS        |
-| **OpenAI Codex CLI**          | JSONL (`~/.codex/sessions/`)  | macOS, Linux |
-| **Warp Terminal**             | SQLite (`warp.sqlite`)        | macOS        |
+| Agent                         | Log Format                    | Platform              |
+| ----------------------------- | ----------------------------- | --------------------- |
+| **Claude Code**               | JSONL (`~/.claude/projects/`) | macOS, Linux          |
+| **Cursor IDE**                | SQLite (`state.vscdb`)        | macOS, Linux, Windows |
+| **Cline (Claude Dev)**        | JSON task files               | macOS, Linux, Windows |
+| **Claude Desktop Agent Mode** | JSONL audit logs              | macOS                 |
+| **OpenAI Codex CLI**          | JSONL (`~/.codex/sessions/`)  | macOS, Linux          |
+| **Warp Terminal**             | SQLite (`warp.sqlite`)        | macOS                 |
 
 
 ## Architecture

--- a/Sensor/adr_sensor/parsers/cline_parser.py
+++ b/Sensor/adr_sensor/parsers/cline_parser.py
@@ -2,10 +2,11 @@
 Parser for Cline (Claude Dev) logs.
 Reads JSON files from the Cline extension's task directories.
 
-Supports both macOS and Linux paths.
+Supports macOS, Linux, and Windows paths.
 """
 
 import json
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -20,7 +21,7 @@ class ClineParser(BaseParser):
     """Parser for Cline (Claude Dev) logs."""
 
     def __init__(self):
-        # Support macOS and Linux paths
+        # Support macOS, Linux, and Windows paths
         macos_path = (
             Path.home()
             / "Library/Application Support/Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks"
@@ -28,7 +29,17 @@ class ClineParser(BaseParser):
         linux_path = (
             Path.home() / ".config/Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks"
         )
-        self.base_path = macos_path if macos_path.exists() else linux_path
+        appdata = os.environ.get("APPDATA")
+        windows_path = (
+            Path(appdata) / "Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks" if appdata else None
+        )
+
+        if macos_path.exists():
+            self.base_path = macos_path
+        elif windows_path is not None and windows_path.exists():
+            self.base_path = windows_path
+        else:
+            self.base_path = linux_path
 
     def parse_all(self) -> List[AgentEvent]:
         """Parse all available Cline logs."""

--- a/Sensor/adr_sensor/parsers/cursor_parser.py
+++ b/Sensor/adr_sensor/parsers/cursor_parser.py
@@ -2,12 +2,13 @@
 Parser for Cursor IDE logs.
 Extracts composerData from SQLite database.
 
-Supports both macOS and Linux paths.
+Supports macOS, Linux, and Windows paths.
 Memory-optimized: Uses cursor iteration instead of fetchall().
 Performance-optimized: Skips conversations older than 2 weeks.
 """
 
 import json
+import os
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -26,11 +27,16 @@ class CursorParser(BaseParser):
     """Parser for Cursor SQLite database logs."""
 
     def __init__(self, max_age_days: int = MAX_CONVERSATION_AGE_DAYS):
-        # Support macOS and Linux paths
+        # Support macOS, Linux, and Windows paths
         macos_path = Path.home() / "Library/Application Support/Cursor/User/globalStorage/state.vscdb"
         linux_path = Path.home() / ".config/Cursor/User/globalStorage/state.vscdb"
+        appdata = os.environ.get("APPDATA")
+        windows_path = Path(appdata) / "Cursor/User/globalStorage/state.vscdb" if appdata else None
+
         if macos_path.exists():
             self.db_path = macos_path
+        elif windows_path is not None and windows_path.exists():
+            self.db_path = windows_path
         else:
             self.db_path = linux_path
         self.max_age_days = max_age_days

--- a/Sensor/tests/test_parsers.py
+++ b/Sensor/tests/test_parsers.py
@@ -12,6 +12,7 @@ import pytest
 from adr_sensor.parsers.claude_parser import ClaudeParser
 from adr_sensor.parsers.cline_parser import ClineParser
 from adr_sensor.parsers.codex_parser import CodexParser
+from adr_sensor.parsers.cursor_parser import CursorParser
 from adr_sensor.parsers.warp_parser import WarpParser
 
 
@@ -98,7 +99,180 @@ class TestClaudeParser:
         assert "[truncated" in result["long"]
 
 
+def _build_cursor_db(db_path: Path, conversations: list) -> None:
+    """Create a synthetic Cursor state.vscdb matching the cursorDiskKV schema
+    CursorParser queries. Each item in `conversations` is a dict with keys:
+        conv_id, metadata (dict with createdAt/lastUpdatedAt), bubbles (list of dicts)
+    """
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)")
+
+    for conv in conversations:
+        conv_id = conv["conv_id"]
+        if conv.get("metadata") is not None:
+            cursor.execute(
+                "INSERT INTO cursorDiskKV VALUES (?, ?)",
+                (f"composerData:{conv_id}", json.dumps(conv["metadata"])),
+            )
+        for bubble in conv.get("bubbles", []):
+            bubble_id = bubble["_bubble_id"]
+            cursor.execute(
+                "INSERT INTO cursorDiskKV VALUES (?, ?)",
+                (f"bubbleId:{conv_id}:{bubble_id}", json.dumps(bubble)),
+            )
+
+    conn.commit()
+    conn.close()
+
+
+class TestCursorParser:
+    def _make_fake_home(self, tmp_path: Path) -> Path:
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        return fake_home
+
+    def test_prefers_macos_path_even_when_appdata_also_has_one(self, tmp_path, monkeypatch):
+        """macOS detection must take precedence, matching the pre-existing
+        macOS-first behavior - this is a regression guard for the new
+        Windows branch, not a statement about which platform "should" win."""
+        fake_home = self._make_fake_home(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        macos_db = fake_home / "Library/Application Support/Cursor/User/globalStorage/state.vscdb"
+        macos_db.parent.mkdir(parents=True)
+        macos_db.write_bytes(b"")
+
+        appdata_dir = tmp_path / "appdata"
+        windows_db = appdata_dir / "Cursor/User/globalStorage/state.vscdb"
+        windows_db.parent.mkdir(parents=True)
+        windows_db.write_bytes(b"")
+        monkeypatch.setenv("APPDATA", str(appdata_dir))
+
+        parser = CursorParser()
+        assert parser.db_path == macos_db
+
+    def test_selects_windows_path_when_appdata_set_and_exists(self, tmp_path, monkeypatch):
+        fake_home = self._make_fake_home(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        appdata_dir = tmp_path / "appdata"
+        windows_db = appdata_dir / "Cursor/User/globalStorage/state.vscdb"
+        windows_db.parent.mkdir(parents=True)
+        windows_db.write_bytes(b"")
+        monkeypatch.setenv("APPDATA", str(appdata_dir))
+
+        parser = CursorParser()
+        assert parser.db_path == windows_db
+
+    def test_falls_back_to_linux_path_when_nothing_exists(self, tmp_path, monkeypatch):
+        """No macOS path, no APPDATA at all - must not crash, and must fall
+        through to the Linux path (pre-existing default-fallback behavior)."""
+        fake_home = self._make_fake_home(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.delenv("APPDATA", raising=False)
+
+        parser = CursorParser()
+        assert parser.db_path == fake_home / ".config/Cursor/User/globalStorage/state.vscdb"
+
+    def test_falls_back_to_linux_when_appdata_set_but_path_missing(self, tmp_path, monkeypatch):
+        """APPDATA is set (as it would be on any real Windows machine) but no
+        Cursor install lives there - must fall through, not falsely select
+        a nonexistent Windows path."""
+        fake_home = self._make_fake_home(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setenv("APPDATA", str(tmp_path / "appdata_without_cursor"))
+
+        parser = CursorParser()
+        assert parser.db_path == fake_home / ".config/Cursor/User/globalStorage/state.vscdb"
+
+    def test_parse_all_no_database(self, tmp_path):
+        """Test parse_all when the database file doesn't exist."""
+        parser = CursorParser()
+        parser.db_path = tmp_path / "nonexistent.vscdb"
+        entries = parser.parse_all()
+        assert entries == []
+
+    def test_parses_conversation_content(self, tmp_path):
+        """Recent conversations should parse into chat history correctly."""
+        now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+        conversations = [
+            {
+                "conv_id": "conv1",
+                "metadata": {"createdAt": now_ms, "lastUpdatedAt": now_ms},
+                "bubbles": [
+                    {"type": 1, "text": "Write a hello world script", "_bubble_id": "b1"},
+                    {"type": 2, "text": "Sure, here it is.", "_bubble_id": "b2"},
+                ],
+            }
+        ]
+        db_path = tmp_path / "state.vscdb"
+        _build_cursor_db(db_path, conversations)
+
+        parser = CursorParser()
+        parser.db_path = db_path
+        entries = parser.parse_all()
+
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.source == "cursor"
+        assert entry.session_id == "cursor_conv1"
+        assert len(entry.chat_history) == 2
+        assert entry.chat_history[0].role == "user"
+        assert "hello world" in entry.chat_history[0].content
+        assert entry.chat_history[1].role == "assistant"
+        assert "here it is" in entry.chat_history[1].content
+
+
 class TestClineParser:
+    def _make_fake_home(self, tmp_path: Path) -> Path:
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        return fake_home
+
+    def test_prefers_macos_path_even_when_appdata_also_has_one(self, tmp_path, monkeypatch):
+        fake_home = self._make_fake_home(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        macos_tasks = fake_home / "Library/Application Support/Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks"
+        macos_tasks.mkdir(parents=True)
+
+        appdata_dir = tmp_path / "appdata"
+        windows_tasks = appdata_dir / "Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks"
+        windows_tasks.mkdir(parents=True)
+        monkeypatch.setenv("APPDATA", str(appdata_dir))
+
+        parser = ClineParser()
+        assert parser.base_path == macos_tasks
+
+    def test_selects_windows_path_when_appdata_set_and_exists(self, tmp_path, monkeypatch):
+        fake_home = self._make_fake_home(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        appdata_dir = tmp_path / "appdata"
+        windows_tasks = appdata_dir / "Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks"
+        windows_tasks.mkdir(parents=True)
+        monkeypatch.setenv("APPDATA", str(appdata_dir))
+
+        parser = ClineParser()
+        assert parser.base_path == windows_tasks
+
+    def test_falls_back_to_linux_path_when_nothing_exists(self, tmp_path, monkeypatch):
+        fake_home = self._make_fake_home(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.delenv("APPDATA", raising=False)
+
+        parser = ClineParser()
+        assert parser.base_path == fake_home / ".config/Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks"
+
+    def test_falls_back_to_linux_when_appdata_set_but_path_missing(self, tmp_path, monkeypatch):
+        fake_home = self._make_fake_home(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setenv("APPDATA", str(tmp_path / "appdata_without_cursor"))
+
+        parser = ClineParser()
+        assert parser.base_path == fake_home / ".config/Cursor/User/globalStorage/saoudrizwan.claude-dev/tasks"
+
     def test_parse_cline_log(self, tmp_path):
         """Test parsing a Cline task directory."""
         task_dir = tmp_path / "1234567890"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

**Related issue**: Closes #21

**What changed?**
`CursorParser` and `ClineParser` now check for an `%APPDATA%`-based Windows install path, added as an `elif` between the existing macOS check and the final Linux fallback, so macOS still takes precedence when present (regression-guarded by a test). Verified (two independent sources) real Windows path for Cursor: `%APPDATA%\Cursor\User\globalStorage\state.vscdb`, mirroring the same Electron-app-data convention already hardcoded for macOS/Linux. Cline's Windows path is derived from that same confirmed Cursor root, since it's a VS-Code extension hosted inside Cursor per the existing macOS/Linux paths. Also backfills `CursorParser`'s test coverage, which was previously zero (unlike its sibling parsers), using the same synthetic-SQLite-fixture technique already established for `WarpParser`. Updates `Sensor/README.md`'s compatibility table for the two affected rows.

**Why?**
The top-level `README.md` claims ADR observes agents "on macOS, Linux, and Windows." In practice, neither parser had any Windows branch, so on a Windows machine both silently returned zero entries for two of the most commonly Windows-installed tools this product claims to observe. Confirmed via a full-repo pass that this is a real, isolated gap: `ClaudeParser`/`CodexParser` already work on Windows with no branching needed, and `ClaudeDesktopParser`/`WarpParser` target apps with no Windows release at all.

**How did you test it?**
Added 8 new tests (4 per parser): macOS still wins when present (regression guard), Windows selected when `APPDATA` is set and the path exists, falls back to Linux when nothing exists or `APPDATA` is unset (no crash), and falls back to Linux when `APPDATA` is set but the path itself doesn't exist. Plus a `CursorParser` content-parsing test against a synthetic SQLite fixture. All use `monkeypatch` on `Path.home`/`APPDATA`, no dependency on real local files, per `Sensor/CONTRIBUTING.md`.

Ran the full suite, `pytest tests/ -v`:

<details>
<summary>74 passed, 1 warning (pre-existing, unrelated) — click to expand</summary>

```
============================= test session starts ==============================
platform darwin -- Python 3.14.0, pytest-9.1.1, pluggy-1.6.0 -- /private/tmp/adr_sensor_venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/test4/Desktop/OSS/Uber ADR/Sensor
configfile: pyproject.toml
collecting ... collected 74 items

tests/test_cli.py::test_cli_version_matches_package_metadata PASSED      [  1%]
tests/test_observer.py::TestAgentObserver::test_init_default PASSED      [  2%]
tests/test_observer.py::TestAgentObserver::test_display_summary_empty PASSED [  4%]
tests/test_observer.py::TestAgentObserver::test_display_summary_with_entries PASSED [  5%]
tests/test_observer.py::TestAgentObserver::test_save_to_file_json PASSED [  6%]
tests/test_observer.py::TestAgentObserver::test_save_to_file_jsonl PASSED [  8%]
tests/test_observer.py::TestAgentObserver::test_save_sessions_individual PASSED [  9%]
tests/test_observer.py::TestAgentObserver::test_clean_filename PASSED    [ 10%]
tests/test_observer.py::TestAgentObserver::test_filter_entries_by_existing_files PASSED [ 12%]
tests/test_observer.py::TestAgentObserver::test_ingest_all_handles_parser_errors PASSED [ 13%]
tests/test_parsers.py::TestClaudeParser::test_parse_jsonl_file PASSED    [ 14%]
tests/test_parsers.py::TestClaudeParser::test_parse_empty_file PASSED    [ 16%]
tests/test_parsers.py::TestClaudeParser::test_parse_all_no_directory PASSED [ 17%]
tests/test_parsers.py::TestClaudeParser::test_truncate_large_arguments PASSED [ 18%]
tests/test_parsers.py::TestCursorParser::test_prefers_macos_path_even_when_appdata_also_has_one PASSED [ 20%]
tests/test_parsers.py::TestCursorParser::test_selects_windows_path_when_appdata_set_and_exists PASSED [ 21%]
tests/test_parsers.py::TestCursorParser::test_falls_back_to_linux_path_when_nothing_exists PASSED [ 22%]
tests/test_parsers.py::TestCursorParser::test_falls_back_to_linux_when_appdata_set_but_path_missing PASSED [ 24%]
tests/test_parsers.py::TestCursorParser::test_parse_all_no_database PASSED [ 25%]
tests/test_parsers.py::TestCursorParser::test_parses_conversation_content PASSED [ 27%]
tests/test_parsers.py::TestClineParser::test_prefers_macos_path_even_when_appdata_also_has_one PASSED [ 28%]
tests/test_parsers.py::TestClineParser::test_selects_windows_path_when_appdata_set_and_exists PASSED [ 29%]
tests/test_parsers.py::TestClineParser::test_falls_back_to_linux_path_when_nothing_exists PASSED [ 31%]
tests/test_parsers.py::TestClineParser::test_falls_back_to_linux_when_appdata_set_but_path_missing PASSED [ 32%]
tests/test_parsers.py::TestClineParser::test_parse_cline_log PASSED      [ 33%]
tests/test_parsers.py::TestClineParser::test_extract_mcp_tools PASSED    [ 35%]
tests/test_parsers.py::TestClineParser::test_parse_no_directory PASSED   [ 36%]
tests/test_parsers.py::TestCodexParser::test_parse_jsonl_file PASSED     [ 37%]
tests/test_parsers.py::TestCodexParser::test_parse_no_directory PASSED   [ 39%]
tests/test_parsers.py::TestWarpParser::test_skips_conversations_older_than_max_age PASSED [ 40%]
tests/test_parsers.py::TestWarpParser::test_all_history_via_large_max_age_days PASSED [ 41%]
tests/test_parsers.py::TestWarpParser::test_parses_conversation_content PASSED [ 43%]
tests/test_parsers.py::TestWarpParser::test_parse_all_no_database PASSED [ 44%]
tests/test_parsers.py::TestWarpParser::test_default_max_age_days PASSED  [ 45%]
tests/test_schemas.py::TestToolUsage::test_create_basic PASSED           [ 47%]
tests/test_schemas.py::TestToolUsage::test_create_with_all_fields PASSED [ 48%]
tests/test_schemas.py::TestToolUsage::test_frozen PASSED                 [ 50%]
tests/test_schemas.py::TestChatMessage::test_create_user_message PASSED  [ 51%]
tests/test_schemas.py::TestChatMessage::test_create_assistant_message_with_tools PASSED [ 52%]
tests/test_schemas.py::TestAgentEvent::test_create_basic PASSED          [ 54%]
tests/test_schemas.py::TestAgentEvent::test_uuid_deterministic PASSED    [ 55%]
tests/test_schemas.py::TestAgentEvent::test_uuid_unique_for_different_sessions PASSED [ 56%]
tests/test_schemas.py::TestAgentEvent::test_has_meaningful_content_empty PASSED [ 58%]
tests/test_schemas.py::TestAgentEvent::test_has_meaningful_content_single_error PASSED [ 59%]
tests/test_schemas.py::TestAgentEvent::test_has_meaningful_content_real_conversation PASSED [ 60%]
tests/test_schemas.py::TestAgentEvent::test_has_meaningful_content_with_tools PASSED [ 62%]
tests/test_schemas.py::TestAgentEvent::test_has_tool_usage PASSED        [ 63%]
tests/test_schemas.py::TestAgentEvent::test_to_dict PASSED               [ 64%]
tests/test_schemas.py::TestAgentEvent::test_to_json PASSED               [ 66%]
tests/test_schemas.py::TestAgentEvent::test_get_summary PASSED           [ 67%]
tests/test_schemas.py::TestAgentEvent::test_get_content_hash PASSED      [ 68%]
tests/test_schemas.py::TestAgentEvent::test_get_non_null_fields PASSED   [ 70%]
tests/test_schemas.py::TestAgentEvent::test_auto_populates_hostname_username PASSED [ 71%]
tests/test_utils.py::TestTruncateMiddle::test_short_string_unchanged PASSED [ 72%]
tests/test_utils.py::TestTruncateMiddle::test_empty_string PASSED        [ 74%]
tests/test_utils.py::TestTruncateMiddle::test_none_string PASSED         [ 75%]
tests/test_utils.py::TestTruncateMiddle::test_exact_length_unchanged PASSED [ 77%]
tests/test_utils.py::TestTruncateMiddle::test_truncation PASSED          [ 78%]
tests/test_utils.py::TestTruncateMiddle::test_custom_edge_chars PASSED   [ 79%]
tests/test_utils.py::TestNormalizeTimestamp::test_iso_string PASSED      [ 81%]
tests/test_utils.py::TestNormalizeTimestamp::test_iso_string_with_offset PASSED [ 82%]
tests/test_utils.py::TestNormalizeTimestamp::test_unix_timestamp_seconds PASSED [ 83%]
tests/test_utils.py::TestNormalizeTimestamp::test_unix_timestamp_milliseconds PASSED [ 85%]
tests/test_utils.py::TestNormalizeTimestamp::test_datetime_naive PASSED  [ 86%]
tests/test_utils.py::TestNormalizeTimestamp::test_datetime_aware PASSED  [ 87%]
tests/test_utils.py::TestNormalizeTimestamp::test_string_unix_timestamp PASSED [ 89%]
tests/test_utils.py::TestNormalizeTimestamp::test_invalid_string PASSED  [ 90%]
tests/test_utils.py::TestNormalizeTimestamp::test_invalid_type PASSED    [ 91%]
tests/test_utils.py::TestNormalizeTimestamp::test_float_timestamp PASSED [ 93%]
tests/test_utils.py::TestFormatTimestampForFilename::test_format PASSED  [ 94%]
tests/test_utils.py::TestParseTimestampFromFilename::test_valid_filename PASSED [ 95%]
tests/test_utils.py::TestParseTimestampFromFilename::test_invalid_filename PASSED [ 97%]
tests/test_utils.py::TestParseTimestampFromFilename::test_none_filename PASSED [ 98%]
tests/test_utils.py::TestParseTimestampFromFilename::test_malformed_timestamp PASSED [100%]

=============================== warnings summary ===============================
tests/test_observer.py::TestAgentObserver::test_ingest_all_handles_parser_errors
  /Users/test4/Desktop/OSS/Uber ADR/Sensor/adr_sensor/observer.py:66: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "timestamp": datetime.utcnow().isoformat(timespec="milliseconds") + "Z",

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 74 passed, 1 warning in 0.16s =========================
```
</details>

**Potential risks**
Low. The Windows branch only activates on platforms where `APPDATA` is set and the specific path exists, on today's macOS/Linux CI and dev machines, `os.environ.get("APPDATA")` returns `None` and the new code path is a no-op, falling straight through to the existing Linux fallback exactly as before.
