### PR TITLE
docs: fix broken markdown around AgentDojo ground_truth.json

### DIFF
--- a/Detection/README.md
+++ b/Detection/README.md
@@ -227,7 +227,7 @@ uv run python main_benchmark.py --benchmark agentdojo --concurrent 3
 - `concurrency_efficiency`: How well concurrency was utilized
 - `overall_mcp_ratio`: Percentage of MCP vs built-in tool usage
 
-**AgentDojo Ground Truth (**`ground_truth.json`**)**:
+**AgentDojo Ground Truth** (`ground_truth.json`):
 
 - `is_malicious`: True if attack succeeded, False if defended
 - `security`: AgentDojo's security field (False = attack succeeded)


### PR DESCRIPTION
<!--

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/uber/ADR/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/uber/ADR/blob/main/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.

     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

<!-- Link any related issue (e.g., "Closes #123"), or "N/A" if there is none -->
**Related issue**: N/A

<!-- Describe what has changed in this PR -->
**What changed?**
Fixed broken bold/backtick nesting in the AgentDojo Ground Truth heading in `Detection/README.md` so `ground_truth.json` renders correctly.
<!-- Tell your future self why have you made these changes -->
**Why?**
The previous markdown nested bold markers around an inline code span incorrectly, which broke rendering on GitHub.
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in a staging env? -->
**How did you test it?**
Verified the updated markdown locally and confirmed the heading renders as intended.
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None — documentation-only change.