### PR TITLE
Add Resemble Detect media-authenticity server to the benchmark registry

### DIFF
--- a/Detection/mcp_servers_registry.json
+++ b/Detection/mcp_servers_registry.json
@@ -2,7 +2,7 @@
   "registry_version": "45.1",
   "description": "MCP servers registry for the ADR Benchmark",
   "last_updated": "2025-01-27",
-  "total_servers": 133,
+  "total_servers": 134,
   "servers": {
     "filesystem": {
       "name": "filesystem",
@@ -2752,6 +2752,31 @@
         "get_recipe_logs"
       ],
       "verified": true
+    },
+    "resemble_detect": {
+      "name": "resemble_detect",
+      "category": "Security",
+      "description": "Deepfake detection and media provenance - analyze audio, image, and video for AI-generated or manipulated content, trace synthetic audio to the platform that produced it, and apply or verify invisible watermarks",
+      "package": "mcp-remote",
+      "type": "community",
+      "command": "npx",
+      "args_template": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.resemble.ai/mcp",
+        "--header",
+        "Authorization: Bearer {resemble_api_key}"
+      ],
+      "capabilities": [
+        "detect_deepfake",
+        "get_detection",
+        "analyze_media",
+        "ask_about_detection",
+        "trace_audio_source",
+        "detect_watermark",
+        "apply_watermark"
+      ],
+      "verified": false
     }
   }
 }


### PR DESCRIPTION
Adds `resemble_detect` to `Detection/mcp_servers_registry.json`, following Option 1 (Community/NPM Servers) in Part 3 of `Detection/README.md`.

### Why this one

The benign corpus already covers media *handling* — `audio_processor`, `image_processor`, `document_processor`, `content_moderator` — but nothing in the registry judges whether a piece of media is authentic. That's a distinct capability class, and one that's becoming common in real agent workloads: an agent receives an audio file or a video and has to decide whether to trust it before acting.

It also gives the benchmark a tool whose *misuse* is interesting. A server that answers "is this real?" is a natural target for the kind of output-manipulation and tool-shadowing attacks this benchmark measures — a compromised authenticity verdict is a high-consequence failure in a way that a weather lookup isn't.

Filed under `Security` (15 existing entries), `verified: false` as the docs specify for new community additions. `total_servers` bumped 133 → 134.

### One thing worth flagging

Resemble Detect is a hosted server (Streamable HTTP at `https://mcp.resemble.ai/mcp`), and every current community entry is a locally-run npm package. I've wired it through `mcp-remote`, the standard stdio-to-remote proxy, so it fits the existing `command`/`args_template` shape without changing the schema:

```json
"args_template": ["-y", "mcp-remote", "https://mcp.resemble.ai/mcp", "--header", "Authorization: Bearer {resemble_api_key}"]
```

This makes it the first remote-backed server in the registry. If you'd rather keep the corpus purely local, or model remote servers with a dedicated field instead, I'm happy to restructure — say the word. Equally, if a FastMCP local server under `context_providers/source_codes/mcp_servers_0/` (Option 2) is the better fit, that's straightforward to do instead.

### Details

- Tools: `detect_deepfake`, `get_detection`, `analyze_media`, `ask_about_detection`, `trace_audio_source`, `detect_watermark`, `apply_watermark`
- Auth: user-supplied Resemble API key as a Bearer token; free keys at https://app.resemble.ai/account/api
- Source: https://github.com/resemble-ai/resemble-mcp (MIT), also in the official MCP registry as `io.github.resemble-ai/resemble-mcp`
- JSON validated: parses cleanly, 134 server entries, count field consistent
