### PR TITLE
Fix case-sensitive ADR triage confidence parsing

### DIFF
--- a/Detection/guardrail/adr_agent/adr_baseline.py
+++ b/Detection/guardrail/adr_agent/adr_baseline.py
@@ -359,11 +359,23 @@ CONFIDENCE: [0.0-1.0]"""
 
         # Extract confidence
         confidence = 0.8  # Default
+        # Match only a dedicated confidence field, not incidental phrases such as
+        # "REASONING: low confidence: agent intent unclear". Models sometimes add
+        # Markdown decoration even though the prompt requests plain field labels.
         confidence_pattern = re.compile(
-            r"^\s*(?:[-*>]\s*)?\**confidence\s*:\**\s*"
-            r"\[?\**\s*(?P<value>(?:\d+(?:\.\d*)?|\.\d+))"
-            r"\s*(?P<percent>%?)\s*\**\]?\s*[.,;:]?\s*$",
-            re.IGNORECASE,
+            r"""
+            ^\s*                         # Start of a line, allowing indentation.
+            (?:[-*>]\s*)?               # Optional Markdown list/quote marker.
+            \**confidence\s*:\**\s*     # Label, optionally wrapped in asterisks.
+            \[?\**\s*                   # Optional bracket/asterisks before value.
+            (?P<value>                   # Decimal confidence value.
+                (?:\d+(?:\.\d*)?|\.\d+)
+            )
+            \s*(?P<percent>%?)           # Optional percentage notation.
+            \s*\**\]?                   # Optional closing asterisks/bracket.
+            \s*[.,;:]?\s*$              # Optional trailing punctuation.
+            """,
+            re.IGNORECASE | re.VERBOSE,
         )
         for line in result_text.splitlines():
             match = confidence_pattern.match(line)

--- a/Detection/guardrail/adr_agent/adr_baseline.py
+++ b/Detection/guardrail/adr_agent/adr_baseline.py
@@ -361,7 +361,7 @@ CONFIDENCE: [0.0-1.0]"""
         confidence = 0.8  # Default
         if "confidence:" in result_lower:
             try:
-                conf_part = result_text.split("confidence:")[1].split()[0].strip()
+                conf_part = result_lower.split("confidence:", 1)[1].split()[0].strip()
                 confidence = float(conf_part)
             except (IndexError, ValueError):
                 confidence = 0.8

--- a/Detection/guardrail/adr_agent/adr_baseline.py
+++ b/Detection/guardrail/adr_agent/adr_baseline.py
@@ -366,14 +366,18 @@ CONFIDENCE: [0.0-1.0]"""
             r"""
             ^\s*                         # Start of a line, allowing indentation.
             (?:[-*>]\s*)?               # Optional Markdown list/quote marker.
-            \**confidence\s*:\**\s*     # Label, optionally wrapped in asterisks.
+            \**                          # Optional opening Markdown emphasis.
+            confidence
+            \**\s*:                      # Emphasis may end before the colon.
+            \**\s*                       # Or it may end after the colon.
             \[?\**\s*                   # Optional bracket/asterisks before value.
             (?P<value>                   # Decimal confidence value.
                 (?:\d+(?:\.\d*)?|\.\d+)
             )
             \s*(?P<percent>%?)           # Optional percentage notation.
             \s*\**\]?                   # Optional closing asterisks/bracket.
-            \s*[.,;:]?\s*$              # Optional trailing punctuation.
+            \s*[.,;:]?                   # Optional trailing punctuation.
+            (?=\s|$)                     # Allow commentary, but not numeric runoff.
             """,
             re.IGNORECASE | re.VERBOSE,
         )
@@ -383,7 +387,11 @@ CONFIDENCE: [0.0-1.0]"""
                 continue
 
             parsed_confidence = float(match.group("value"))
-            if match.group("percent"):
+            # Special case: treat percentage values at or above 1 as a 0-100
+            # scale ("1%" -> 0.01), but preserve values below 1 unchanged
+            # ("0.95%" -> 0.95). The latter intentionally favors the likely
+            # model intent: an already-normalized confidence with an extra "%".
+            if match.group("percent") and parsed_confidence >= 1.0:
                 parsed_confidence /= 100
             if 0.0 <= parsed_confidence <= 1.0:
                 confidence = parsed_confidence

--- a/Detection/guardrail/adr_agent/adr_baseline.py
+++ b/Detection/guardrail/adr_agent/adr_baseline.py
@@ -359,12 +359,23 @@ CONFIDENCE: [0.0-1.0]"""
 
         # Extract confidence
         confidence = 0.8  # Default
-        if "confidence:" in result_lower:
-            try:
-                conf_part = result_lower.split("confidence:", 1)[1].split()[0].strip()
-                confidence = float(conf_part)
-            except (IndexError, ValueError):
-                confidence = 0.8
+        confidence_pattern = re.compile(
+            r"^\s*(?:[-*>]\s*)?\**confidence\s*:\**\s*"
+            r"\[?\**\s*(?P<value>(?:\d+(?:\.\d*)?|\.\d+))"
+            r"\s*(?P<percent>%?)\s*\**\]?\s*[.,;:]?\s*$",
+            re.IGNORECASE,
+        )
+        for line in result_text.splitlines():
+            match = confidence_pattern.match(line)
+            if not match:
+                continue
+
+            parsed_confidence = float(match.group("value"))
+            if match.group("percent"):
+                parsed_confidence /= 100
+            if 0.0 <= parsed_confidence <= 1.0:
+                confidence = parsed_confidence
+                break
 
         # Extract reasoning (note: prompt says "REASONING:", not "REASON:")
         reason = "Fast triage assessment"  # Default

--- a/Detection/tests/test_adr_baseline.py
+++ b/Detection/tests/test_adr_baseline.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from guardrail.adr_agent.adr_baseline import ADSConfig, ReasoningAgent, TriageLLM, _safe_task_id_for_path
 
 
@@ -34,12 +36,28 @@ class TestTriageParsing:
         assert result.threat_tactic == "N/A"
         assert result.confidence == 0.2
 
-    def test_parse_uppercase_confidence_from_prompt_format(self):
+    @pytest.mark.parametrize(
+        ("triage_output", "expected_confidence"),
+        [
+            ("CONFIDENCE: 0.99", 0.99),
+            ("**CONFIDENCE:** 0.95", 0.95),
+            ("REASONING: low confidence: agent intent unclear\nCONFIDENCE: 0.30", 0.30),
+            ("CONFIDENCE: 0.75.", 0.75),
+            ("CONFIDENCE: 95%", 0.95),
+        ],
+    )
+    def test_parse_common_confidence_formats(self, triage_output, expected_confidence):
         triage = TriageLLM(MagicMock(), ADSConfig())
         result = triage._parse_triage_result(
-            "CLASSIFICATION: BENIGN\nTHREAT_TACTIC: N/A\nREASONING: routine request\nCONFIDENCE: 0.99"
+            f"CLASSIFICATION: BENIGN\nTHREAT_TACTIC: N/A\n{triage_output}"
         )
-        assert result.confidence == 0.99
+        assert result.confidence == expected_confidence
+
+    @pytest.mark.parametrize("triage_output", ["CONFIDENCE: 1.1", "CONFIDENCE: 101%"])
+    def test_out_of_range_confidence_uses_default(self, triage_output):
+        triage = TriageLLM(MagicMock(), ADSConfig())
+        result = triage._parse_triage_result(triage_output)
+        assert result.confidence == 0.8
 
     def test_parse_suspicious_result(self):
         triage = TriageLLM(MagicMock(), ADSConfig())

--- a/Detection/tests/test_adr_baseline.py
+++ b/Detection/tests/test_adr_baseline.py
@@ -34,6 +34,13 @@ class TestTriageParsing:
         assert result.threat_tactic == "N/A"
         assert result.confidence == 0.2
 
+    def test_parse_uppercase_confidence_from_prompt_format(self):
+        triage = TriageLLM(MagicMock(), ADSConfig())
+        result = triage._parse_triage_result(
+            "CLASSIFICATION: BENIGN\nTHREAT_TACTIC: N/A\nREASONING: routine request\nCONFIDENCE: 0.99"
+        )
+        assert result.confidence == 0.99
+
     def test_parse_suspicious_result(self):
         triage = TriageLLM(MagicMock(), ADSConfig())
         result = triage._parse_triage_result(

--- a/Detection/tests/test_adr_baseline.py
+++ b/Detection/tests/test_adr_baseline.py
@@ -44,6 +44,14 @@ class TestTriageParsing:
             ("REASONING: low confidence: agent intent unclear\nCONFIDENCE: 0.30", 0.30),
             ("CONFIDENCE: 0.75.", 0.75),
             ("CONFIDENCE: 95%", 0.95),
+            ("CONFIDENCE: 95.1%", 0.951),
+            ("CONFIDENCE: 0.95%", 0.95),
+            ("CONFIDENCE: 1%", 0.01),
+            ("confidence: 0.9 - agent behavior normal", 0.9),
+            ("CONFIDENCE: 0.9 (high)", 0.9),
+            ("**CONFIDENCE**: 0.95", 0.95),
+            ("*CONFIDENCE*: 0.9", 0.9),
+            ("> **Confidence**: 0.6", 0.6),
         ],
     )
     def test_parse_common_confidence_formats(self, triage_output, expected_confidence):
@@ -53,8 +61,17 @@ class TestTriageParsing:
         )
         assert result.confidence == expected_confidence
 
-    @pytest.mark.parametrize("triage_output", ["CONFIDENCE: 1.1", "CONFIDENCE: 101%"])
-    def test_out_of_range_confidence_uses_default(self, triage_output):
+    @pytest.mark.parametrize(
+        "triage_output",
+        [
+            "CONFIDENCE: 1.1",
+            "CONFIDENCE: 101%",
+            "CONFIDENCE: 0.95.2",
+            "CONFIDENCE: 0.95high",
+            "CLASSIFICATION: BENIGN | CONFIDENCE: 0.9",
+        ],
+    )
+    def test_invalid_confidence_uses_default(self, triage_output):
         triage = TriageLLM(MagicMock(), ADSConfig())
         result = triage._parse_triage_result(triage_output)
         assert result.confidence == 0.8


### PR DESCRIPTION
## Summary

- parse ADR triage confidence from the already normalized lowercase response
- add regression coverage for the uppercase `CONFIDENCE:` format requested by the triage prompt

## Problem

The parser detects `confidence:` in a lowercased copy of the model response, but then splits the original response using the lowercase field name. When a model follows ADR's requested uppercase `CONFIDENCE:` format, that split fails and the parser silently returns the default confidence of `0.8`.

This does not change the triage classification. It fixes the confidence recorded for Tier 1 results.

## Test plan

```text
cd Detection
pytest tests/test_adr_baseline.py -q
13 passed
```
