### PR TITLE
docs: list ADR Discovery as a top-level module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ADR is **deployed in production at Uber**, and the accompanying paper was accept
 
 ADR secures enterprise AI agents through five complementary capabilities: discovering unsanctioned AI tools, observing agent activity, evaluating defenses, detecting threats, and preventing unsafe actions.
 
-1. **ADR Discovery: Find the AI tools present on employee endpoints.** Inventories installed AI applications, CLI agents, local model runtimes, and MCP servers. This component is not included in the current open-source release. **Stay tuned.**
+1. **ADR Discovery: Find the AI tools present on employee endpoints.** Inventories installed AI applications, CLI agents, IDE extensions, local model runtimes, and MCP servers, and flags unknown surfaces for review.
 2. **ADR Observability: Understand what AI agents are doing and why.** In production, ADR captures agent intent, tool use, and execution traces across 7+ AI coding tools on macOS, Linux, and Windows, as well as internal automation and customer-facing support agents.
 3. **ADR Benchmark: Test agent security under realistic enterprise conditions.** ADR-Bench includes 300+ tasks, 133 MCP servers, and coverage of all 17 agent attack techniques.
 4. **ADR Detection: Detect risky agent behavior efficiently.** Its two-tier architecture combines high-recall triage with deeper agentic reasoning for suspicious sessions.
@@ -16,10 +16,11 @@ ADR secures enterprise AI agents through five complementary capabilities: discov
 
 ## Repository layout
 
-This repository contains the open-source **ADR Sensor**, **ADR-Bench**, and **ADR Detector** described in the paper. The offline **ADR Explorer** engine, which hardens ADR Detection through pre-deployment red teaming, is not included here.
+This repository contains the open-source **ADR Discovery**, **ADR Sensor**, **ADR-Bench**, and **ADR Detector** described in the paper. The offline **ADR Explorer** engine, which hardens ADR Detection through pre-deployment red teaming, is not included here.
 
 | Path                                               | ADR component              | Description                                                                          |
 | -------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------ |
+| [Discovery/](Discovery/)                           | ADR Discovery              | Inventory the AI apps, CLI agents, IDE extensions, model runtimes, and MCP servers on an endpoint, and flag unknown surfaces for review |
 | [Sensor/](Sensor/)                                 | ADR Observability          | Collect and normalize agent telemetry from Claude Code, Cursor, Codex, opencode, Claude Desktop, and others |
 | [Detection/](Detection/)                           | ADR Benchmark + Detection  | Dual-agent detector, 133 MCP servers, 303 benchmark tasks, baselines, figure scripts |
 | [docs/REPRODUCIBILITY.md](docs/REPRODUCIBILITY.md) | Evaluation                 | Step-by-step workflow to reproduce benchmark detection and paper figures             |
@@ -39,6 +40,7 @@ See **[docs/REPRODUCIBILITY.md](docs/REPRODUCIBILITY.md)** for the full evaluati
 
 Component documentation:
 
+- [Discovery/README.md](Discovery/README.md): endpoint inventory, probes, and the fingerprint catalog
 - [Sensor/README.md](Sensor/README.md): telemetry collection and unified schema
 - [Detection/README.md](Detection/README.md): ADR-Bench, detector baselines, MCP infrastructure
 


### PR DESCRIPTION
Presents ADR Discovery as its own module in the README rather than as part of the Sensor.

## What changed

`README.md` only, 4 insertions and 2 deletions:

- **Repository layout table** gains a `Discovery/` row, listed first to match the capability ordering in the section above it.
- **Capability overview** no longer says Discovery "is not included in the current open-source release. **Stay tuned.**", and the description now covers IDE extensions and the open-world review queue.
- **Prose list** of open-source components leads with ADR Discovery.
- **Component documentation** gains a `Discovery/README.md` bullet.

## Reviewer note: two links do not resolve yet

This is the documentation half of a larger change, so `Discovery/` and `Discovery/README.md` will 404 until the endpoint collector actually moves. The collector currently lives on an unmerged branch under `Sensor/adr_sensor/discovery/`.

Merging this before the code move means `main` briefly advertises a directory it does not have. That is a deliberate tradeoff and worth a decision: hold this until the move lands, or take it now so the intended layout is documented up front.

The collector extraction is mechanical whenever it happens — nothing in `discovery/` imports from `adr_sensor` outside its own package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)