### PR TITLE
docs(discovery): correct the Goose install row in the test plan

### DIFF
--- a/Discovery/tests/README.md
+++ b/Discovery/tests/README.md
@@ -94,12 +94,14 @@ Installed globally so their binaries land on `PATH`. Versions are pinned, becaus
 | `T-CLI-06` | Kilo CLI | `kilo-cli` | `npm i -g @kilocode/cli@<pin>` | ✓ | ✓ | ✓ |
 | `T-CLI-07` | Qwen Code | `qwen-code` | `npm i -g @qwen-code/qwen-code@<pin>` | ✓ | ✓ | ✓ |
 | `T-CLI-08` | Copilot CLI | `copilot-cli` | `npm i -g @github/copilot@<pin>` | ✓ | ✓ | ✓ |
-| `T-CLI-09` | Goose | `goose` | `npm i -g @block/goose-cli@<pin>` | ✓ | ✓ | ✓ |
+| `T-CLI-09` | Goose | `goose` | vendor installer — **not npm**, see below | ✓ | ✓ | ✓ |
 | `T-CLI-10` | Aider | `aider` | `pipx install aider-chat==<pin>` | ✓ | ✓ | ✓ |
 | `T-CLI-11` | Crush | `crush` | vendor binary → `/usr/local/bin` | ✓ | ✓ | ✓ |
 | `T-CLI-12` | Grok CLI | `grok-cli` | vendor binary → `/usr/local/bin` | ✓ | ✓ | ✓ |
 
 Expected for each: one asset, correct `version`, `install_path` on the real binary, `install_method` matching the channel, `liveness` = installed.
+
+`T-CLI-09` is the one row where the install channel is not settled. `@block/goose-cli` does not resolve — the scope does not exist on the npm registry — and the plausible substitute is worse than nothing: the unscoped `goose-cli` package on npm is a wrapper around the **database migration tool** of the same name, so installing it would put an unrelated binary called `goose` on `PATH` and the harness would record a successful install of the wrong product. The row stays in the manifest and is recorded `unimplemented` until somebody confirms how Block ships it.
 
 #### 1b. Desktop apps, IDEs and AI browsers — `T-APP-01` … `T-APP-16`
 


### PR DESCRIPTION
The test plan installs `T-CLI-09` with `npm i -g @block/goose-cli@<pin>`. That package does not exist: the `@block` scope has no `goose-cli` on the npm registry, and a live install run against an Ubuntu guest surfaced it as a 404 rather than as a version mismatch.

The obvious substitution is the trap, and it is why this is worth its own change. The unscoped `goose-cli` package on npm is a wrapper around the **database migration tool** of the same name. Taking it would put an unrelated binary called `goose` on `PATH`, and the harness would record a successful install of the wrong product — a false positive manufactured by the test rig itself rather than found in the collector.

The row stays in the inventory with its channel marked unsettled, so the entry is visible as unresolved rather than quietly dropped.

## Verification

```
$ curl -s https://registry.npmjs.org/@block%2fgoose-cli
{"error":"Not found"}

$ curl -s https://registry.npmjs.org/goose-cli | jq -r .description
A wrapper for the goose database migration tool.
```

Every other CLI row in that table installs cleanly at a pinned version; this is the only one that does not resolve.