### PR TITLE
test(discovery): add the 120-entry install manifest

### DIFF
--- a/Discovery/tests/__init__.py
+++ b/Discovery/tests/__init__.py
@@ -1,0 +1,14 @@
+"""End-to-end fidelity harness for ADR Discovery.
+
+Implements the method in ``Discovery/tests/README.md``: install a known set of
+AI tools on a clean VM, scan, and score what the collector reported against
+what was actually installed.
+
+The package boundary is deliberately a file on disk rather than a function
+call. ``manifest.actual.json`` and the two snapshots are plain files, so a
+failed run can be re-scored without re-running it, a scoring fix can be
+replayed against every historical run, and nobody debugging a false positive
+needs a VM to do it.
+"""
+
+__all__ = ["manifest", "scoring", "install", "provision", "report"]

--- a/Discovery/tests/manifest.py
+++ b/Discovery/tests/manifest.py
@@ -1,0 +1,313 @@
+"""The manifest: what we intend to install, and what we expect back.
+
+This module is the only place that reads ``manifests/*.yaml``. Everything
+downstream - the runner, the scorer, the report - works on :class:`Entry`
+objects, so a change to the file format touches one file.
+
+The three checks at the bottom need no VM. They are static properties of the
+manifest and the catalog, so they run per-commit in ordinary CI: the expensive
+instrument should never be the thing that discovers a typo.
+"""
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+try:  # Python 3.11+
+    import tomllib
+except ImportError:  # pragma: no cover - older interpreters
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ImportError as exc:
+        raise SystemExit("the e2e harness needs tomllib (Python 3.11+) or tomli") from exc
+
+MANIFEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "manifests")
+
+#: The files that make up the manifest, in the order a reader should meet them.
+MANIFEST_FILES = ("tools.toml", "mcp.toml", "artifacts.toml", "agents.toml", "negative.toml")
+
+PLATFORMS = ("mac", "linux", "win")
+
+#: Fourteen recipe families cover all 120 entries. Adding a tool that uses an
+#: existing family is a manifest edit with no code, which is the property that
+#: keeps the inventory cheap to grow.
+FAMILIES = frozenset({
+    "declare-mcp", "artifact", "app-installer", "service", "npm-global", "channel-variant",
+    "vscode-ext", "scheduler", "identity", "baseline-prereq", "runtime-state", "vendor-binary",
+    "non-ai-app", "pipx",
+})
+
+#: Which report table an entry belongs to. Recall is reported per category
+#: because the categories fail for different reasons and pooling them hides
+#: which surface regressed.
+CATEGORIES = ("cli_agent", "app", "extension", "model_runtime", "channel_variant",
+              "mcp_server", "artifact", "agent", "negative_control")
+
+CANARY_REF = re.compile(r"\{\{canary:([a-z0-9_]+)\}\}")
+
+_SUBCATEGORY_TO_CATEGORY = {
+    "cli_agent": "cli_agent",
+    "app": "app",
+    "extension": "extension",
+    "model_runtime": "model_runtime",
+    "channel_variant": "channel_variant",
+    "mcp_site": "mcp_server",
+    "mcp_launch": "mcp_server",
+    "mcp_special": "mcp_server",
+    "skill": "artifact",
+    "command": "artifact",
+    "style": "artifact",
+    "subagent": "artifact",
+    "plugin": "artifact",
+    "hook": "artifact",
+    "instructions": "artifact",
+    "runtime_state": "agent",
+    "scheduled": "agent",
+    "identity": "agent",
+    "env_credential": "agent",
+    "prerequisite": "negative_control",
+    "non_ai_app": "negative_control",
+    "lookalike": "negative_control",
+    "open_world": "negative_control",
+}
+
+
+class ManifestError(ValueError):
+    """A manifest that cannot be trusted to describe a run."""
+
+
+@dataclass
+class Entry:
+    """One row of the manifest: a stable id and everything it implies.
+
+    The id is what the runner executes, what ``manifest.actual.json`` records
+    an outcome against, and what a scorecard reports a miss under. It is the
+    join key for the whole harness, which is why nothing here is allowed to
+    exist without one.
+    """
+
+    id: str
+    name: str
+    category: str
+    subcategory: str
+    platforms: List[str]
+    family: str
+    catalog_id: Optional[str] = None
+    install: Dict[str, Any] = field(default_factory=dict)
+    declare: Dict[str, Any] = field(default_factory=dict)
+    create: Dict[str, Any] = field(default_factory=dict)
+    state: Dict[str, Any] = field(default_factory=dict)
+    expect: Dict[str, Any] = field(default_factory=dict)
+    canaries: List[str] = field(default_factory=list)
+    depends_on: List[str] = field(default_factory=list)
+    variant_of: Optional[str] = None
+    verify: Optional[str] = None
+    privileged: bool = False
+    must_not_appear: bool = False
+    must_be_reviewed: bool = False
+    must_not_be: Optional[str] = None
+    explains_error: bool = False
+    reason: Optional[str] = None
+    detect: Dict[str, Any] = field(default_factory=dict)
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def shape(self) -> str:
+        """Which block the entry carries, which is what matching keys off.
+
+        Four shapes cover all 120 rows, and the shape - not the category -
+        decides how an entry is matched to an asset.
+        """
+        if self.declare:
+            return "declare"
+        if self.create:
+            return "create"
+        if self.state:
+            return "state"
+        return "install"
+
+    @property
+    def is_negative(self) -> bool:
+        return self.category == "negative_control"
+
+    def applies_to(self, platform: str) -> bool:
+        """An entry absent from a platform list is never scored as a miss there."""
+        return platform in self.platforms
+
+    def path_for(self, platform: str) -> Optional[str]:
+        """The path this entry writes on ``platform``, if it writes one.
+
+        Paths are per-OS for most artifacts and a bare string for the rest, so
+        callers get one accessor instead of repeating the isinstance dance.
+        """
+        block = self.create or self.declare
+        path = block.get("path")
+        if isinstance(path, dict):
+            return path.get(platform)
+        return path
+
+
+def load(directory: str = MANIFEST_DIR) -> "Manifest":
+    """Read every manifest file into one validated :class:`Manifest`."""
+    entries: List[Entry] = []
+    for name in MANIFEST_FILES:
+        path = os.path.join(directory, name)
+        with open(path, "rb") as handle:
+            document = tomllib.load(handle)
+        if not document or "entries" not in document:
+            raise ManifestError("%s declares no entries" % name)
+        for row in document["entries"]:
+            entries.append(_entry(row, source=name))
+    canaries = _load_side_file(directory, "canaries.toml", "canaries")
+    sources = _load_side_file(directory, "sources.toml", "sources")
+    manifest = Manifest(entries=entries, canaries=canaries, sources=sources)
+    manifest.validate()
+    return manifest
+
+
+def _load_side_file(directory: str, name: str, key: str) -> Any:
+    with open(os.path.join(directory, name), "rb") as handle:
+        return (tomllib.load(handle) or {}).get(key) or {}
+
+
+def _entry(row: Dict[str, Any], source: str) -> Entry:
+    try:
+        subcategory = row["subcategory"]
+        entry = Entry(
+            id=row["id"],
+            name=row["name"],
+            subcategory=subcategory,
+            category=_SUBCATEGORY_TO_CATEGORY[subcategory],
+            platforms=list(row["platforms"]),
+            family=_family(row),
+            catalog_id=row.get("catalog_id"),
+            install=dict(row.get("install") or {}),
+            declare=dict(row.get("declare") or {}),
+            create=dict(row.get("create") or {}),
+            state=dict(row.get("state") or {}),
+            expect=dict(row.get("expect") or {}),
+            canaries=list(row.get("canaries") or []),
+            depends_on=list(row.get("depends_on") or []),
+            variant_of=row.get("variant_of"),
+            verify=row.get("verify"),
+            privileged=bool(row.get("privileged")),
+            must_not_appear=bool(row.get("must_not_appear")),
+            must_be_reviewed=bool(row.get("must_be_reviewed")),
+            must_not_be=row.get("must_not_be"),
+            explains_error=bool(row.get("explains_error")),
+            reason=row.get("reason"),
+            detect=dict(row.get("detect") or {}),
+            raw=row,
+        )
+    except KeyError as exc:
+        raise ManifestError("%s: entry %r is missing %s" % (source, row.get("id", "?"), exc)) from exc
+    return entry
+
+
+def _family(row: Dict[str, Any]) -> str:
+    """Derive the recipe family from the block the entry carries.
+
+    Derived rather than declared so the two can never disagree: a row that says
+    ``family: artifact`` while carrying an ``install`` block would be executed
+    one way and reported another.
+    """
+    if row.get("declare"):
+        return "declare-mcp"
+    if row.get("create"):
+        return "artifact"
+    if row.get("state"):
+        method = row["state"].get("method")
+        if method not in FAMILIES:
+            raise ManifestError("%s: unknown state method %r" % (row.get("id"), method))
+        return method
+    method = (row.get("install") or {}).get("method")
+    if method not in FAMILIES:
+        raise ManifestError("%s: unknown install method %r" % (row.get("id"), method))
+    return method
+
+
+@dataclass
+class Manifest:
+    """The whole inventory, plus the two side files it references."""
+
+    entries: List[Entry]
+    canaries: List[Dict[str, Any]] = field(default_factory=list)
+    sources: Dict[str, Any] = field(default_factory=dict)
+
+    def __iter__(self) -> Iterable[Entry]:
+        return iter(self.entries)
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+    def by_id(self, entry_id: str) -> Entry:
+        for entry in self.entries:
+            if entry.id == entry_id:
+                return entry
+        raise KeyError(entry_id)
+
+    def for_platform(self, platform: str) -> List[Entry]:
+        """The applicable set for one OS - the denominator for its recall."""
+        if platform not in PLATFORMS:
+            raise ManifestError("unknown platform %r" % platform)
+        return [entry for entry in self.entries if entry.applies_to(platform)]
+
+    def canary_names(self) -> List[str]:
+        return [item["name"] for item in self.canaries]
+
+    # -- validation ----------------------------------------------------
+
+    def validate(self) -> None:
+        """The structural rules the format enforces, at load time.
+
+        Load-time rather than run-time because the alternative is discovering a
+        broken row twenty minutes into a VM run that then has to start again.
+        """
+        problems: List[str] = []
+        problems.extend(self._check_pins())
+        problems.extend(self._check_references())
+        if problems:
+            raise ManifestError("manifest is invalid:\n  " + "\n  ".join(problems))
+
+    def _check_pins(self) -> List[str]:
+        """Every installed package names a version.
+
+        An unpinned install makes the expected ``version`` unscoreable, because
+        the right answer becomes whatever the registry served that morning.
+        """
+        problems = []
+        for entry in self.entries:
+            if entry.family in ("npm-global", "pipx", "vscode-ext") and not entry.install.get("version"):
+                problems.append("%s installs %s unpinned"
+                                % (entry.id, entry.install.get("package") or entry.install.get("extension_id")))
+        return problems
+
+    def _check_references(self) -> List[str]:
+        """``depends_on`` and ``variant_of`` must name rows that exist.
+
+        A variant that names a base the scorer cannot find would be counted as
+        a second asset rather than as the duplicate it exists to provoke.
+        """
+        problems = []
+        known = {entry.id for entry in self.entries}
+        for entry in self.entries:
+            for reference in list(entry.depends_on) + ([entry.variant_of] if entry.variant_of else []):
+                if reference not in known:
+                    problems.append("%s references unknown entry %s" % (entry.id, reference))
+            if entry.variant_of:
+                base = next(item for item in self.entries if item.id == entry.variant_of)
+                for platform in entry.platforms:
+                    if not base.applies_to(platform):
+                        problems.append("%s is a %s variant of %s, which does not apply there"
+                                        % (entry.id, platform, base.id))
+        return problems
+
+
+def _serialize(value: Any) -> str:
+    """Flatten a nested row to text, for substring checks over the whole of it."""
+    if isinstance(value, dict):
+        return " ".join(_serialize(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return " ".join(_serialize(item) for item in value)
+    return str(value)

--- a/Discovery/tests/manifests/agents.toml
+++ b/Discovery/tests/manifests/agents.toml
@@ -1,0 +1,134 @@
+# Category 4 of Discovery/tests/README.md: the 12 agent entries.
+#
+# Agents are distinguished from tools by *liveness*, so each is left in the
+# required state immediately before the second scan - which is why the runner
+# executes runtime-state last and why nothing between it and the scan may
+# restart the machine.
+#
+# AG-08 .. AG-11 cannot be automated: OAuth device flows resist unattended
+# scripting. They are signed in by hand once while building the golden image
+# and captured in the snapshot. The run *asserts* those sessions are still
+# valid and fails loudly if they have expired, because a silently expired
+# session records four quiet misses and blames the collector for them.
+version = 1
+category = "agent"
+
+[[entries]]
+id = "AG-01"
+name = "Running agent"
+subcategory = "runtime_state"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-CLI-01"]
+state = { method = "runtime-state", launch = "claude", detach = true, hold_until_scan = true }
+expect = { kind = "cli_agent", liveness = "running" }
+
+[[entries]]
+id = "AG-02"
+name = "Spawned child"
+subcategory = "runtime_state"
+platforms = ["mac", "linux", "win"]
+depends_on = ["AG-01"]
+state = { method = "runtime-state", parent = "AG-01", launch = "sleep 3600", detach = true, hold_until_scan = true }
+expect = { parent_agent = "claude-code" }
+
+[[entries]]
+id = "AG-03"
+name = "Running runtime"
+subcategory = "runtime_state"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-RT-01"]
+state = { method = "runtime-state", launch = "ollama serve", detach = true, hold_until_scan = true }
+expect = { kind = "model_runtime", liveness = "running" }
+
+[[entries]]
+id = "AG-04"
+name = "launchd agent"
+subcategory = "scheduled"
+platforms = ["mac"]
+depends_on = ["T-CLI-01"]
+state = { method = "scheduler", backend = "launchd", path = "~/Library/LaunchAgents/com.adr.e2e.agent.plist", schedule = "0 * * * *", command = "claude -p 'nightly triage'" }
+expect = { kind = "scheduled_agent", liveness = "scheduled" }
+
+[[entries]]
+id = "AG-05"
+name = "cron job"
+subcategory = "scheduled"
+platforms = ["linux"]
+depends_on = ["T-CLI-01"]
+state = { method = "scheduler", backend = "cron", schedule = "0 * * * *", command = "claude -p 'nightly triage'" }
+expect = { kind = "scheduled_agent", liveness = "scheduled" }
+
+[[entries]]
+id = "AG-06"
+name = "systemd user unit"
+subcategory = "scheduled"
+platforms = ["linux"]
+depends_on = ["T-CLI-01"]
+state = { method = "scheduler", backend = "systemd", path = "~/.config/systemd/user/adr-agent.service", command = "claude -p 'nightly triage'" }
+expect = { kind = "scheduled_agent", liveness = "scheduled" }
+
+[[entries]]
+id = "AG-07"
+name = "Scheduled task"
+subcategory = "scheduled"
+platforms = ["win"]
+depends_on = ["T-CLI-01"]
+state = { method = "scheduler", backend = "schtasks", task_name = "ADR E2E Agent", schedule = "HOURLY", command = "claude -p 'nightly triage'" }
+expect = { kind = "scheduled_agent", liveness = "scheduled" }
+
+# Baked into the golden image, never scripted. `assert_only` tells the runner to
+# verify rather than create, and to fail the run - not the entry - when the
+# assertion does not hold.
+
+[[entries]]
+id = "AG-08"
+name = "Claude Code identity"
+subcategory = "identity"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-CLI-01"]
+state = { method = "identity", tool = "claude-code", account = "corporate", assert_only = true }
+expect = { kind = "cli_agent", has_identity = true }
+
+[[entries]]
+id = "AG-09"
+name = "Codex identity"
+subcategory = "identity"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-CLI-02"]
+state = { method = "identity", tool = "codex", account = "corporate", assert_only = true }
+expect = { kind = "cli_agent", has_identity = true }
+
+[[entries]]
+id = "AG-10"
+name = "Gemini CLI identity"
+subcategory = "identity"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-CLI-03"]
+state = { method = "identity", tool = "gemini-cli", account = "corporate", assert_only = true }
+expect = { kind = "cli_agent", has_identity = true }
+
+[[entries]]
+id = "AG-11"
+name = "Personal account"
+subcategory = "identity"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-CLI-04"]
+state = { method = "identity", tool = "opencode", account = "personal", assert_only = true }
+expect = { kind = "cli_agent", has_identity = true, risk_factor = "personal_account" }
+
+# The variable *name* is the signal and must be reported; the value is the
+# canary and must not survive serialization.
+
+[[entries]]
+id = "AG-12"
+name = "Shell-exported key"
+subcategory = "env_credential"
+platforms = ["mac", "linux", "win"]
+canaries = ["env_key"]
+expect = { env_name = "ANTHROPIC_API_KEY" }
+[entries.create]
+kind = "append"
+body = "shell_export"
+variable = "ANTHROPIC_API_KEY"
+value = "{{canary:env_key}}"
+path = { mac = "~/.zshrc", linux = "~/.bashrc", win = "%USERPROFILE%/Documents/WindowsPowerShell/profile.ps1" }

--- a/Discovery/tests/manifests/artifacts.toml
+++ b/Discovery/tests/manifests/artifacts.toml
@@ -1,0 +1,169 @@
+# Category 3 of Discovery/tests/README.md: the 19 programmable-surface entries.
+#
+# What an installed agent has been *told* to do. Created as real files, because
+# every one of these is discovered by reading a path that must exist exactly
+# where the collector looks. Project-level artifacts go in checkouts under
+# ~/dev, ~/src, ~/workspace and ~/code, since those are the roots it walks.
+#
+# S-13 .. S-16 carry the most weight: a hook is arbitrary code that runs on an
+# agent event, so each must be reported with its command visible enough to
+# review - and S-16 with the canary redacted out of it.
+version = 1
+category = "artifact"
+
+[[entries]]
+id = "S-01"
+name = "User skill"
+subcategory = "skill"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.claude/skills/pdf-filler/SKILL.md", body = "skill" }
+expect = { kind = "skill", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-02"
+name = "Project skill"
+subcategory = "skill"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/dev/demo-repo/.claude/skills/deploy-check/SKILL.md", body = "skill" }
+expect = { kind = "skill", install_method = "agent_artifact", config_scope = "project" }
+
+[[entries]]
+id = "S-03"
+name = "Claude command"
+subcategory = "command"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.claude/commands/ship.md", body = "command" }
+expect = { kind = "skill", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-04"
+name = "Gemini command"
+subcategory = "command"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.gemini/commands/review.toml", body = "command_toml" }
+expect = { kind = "skill", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-05"
+name = "Codex prompt"
+subcategory = "command"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.codex/prompts/triage.md", body = "command" }
+expect = { kind = "skill", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-06"
+name = "Project command"
+subcategory = "command"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/dev/demo-repo/.claude/commands/release.md", body = "command" }
+expect = { kind = "skill", install_method = "agent_artifact", config_scope = "project" }
+
+[[entries]]
+id = "S-07"
+name = "Output style"
+subcategory = "style"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.claude/output-styles/terse.md", body = "output_style" }
+expect = { kind = "skill", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-08"
+name = "Claude subagent"
+subcategory = "subagent"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.claude/agents/reviewer.md", body = "subagent" }
+expect = { kind = "agent", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-09"
+name = "Cursor agent"
+subcategory = "subagent"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.cursor/agents/refactor.md", body = "subagent" }
+expect = { kind = "agent", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-10"
+name = "Windsurf agent"
+subcategory = "subagent"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.codeium/windsurf/agents/scan.md", body = "subagent" }
+expect = { kind = "agent", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-11"
+name = "Project subagent"
+subcategory = "subagent"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/dev/demo-repo/.claude/agents/tester.md", body = "subagent" }
+expect = { kind = "agent", install_method = "agent_artifact", config_scope = "project" }
+
+[[entries]]
+id = "S-12"
+name = "Plugin"
+subcategory = "plugin"
+platforms = ["mac", "linux", "win"]
+create = { kind = "directory", path = "~/.claude/plugins/acme-tools/", body = "plugin" }
+expect = { kind = "plugin", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-13"
+name = "User hook"
+subcategory = "hook"
+platforms = ["mac", "linux", "win"]
+create = { kind = "merge", path = "~/.claude/settings.json", body = "hook", event = "PreToolUse", command = "~/bin/audit.sh --event pre" }
+expect = { kind = "hook", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-14"
+name = "Project hook"
+subcategory = "hook"
+platforms = ["mac", "linux", "win"]
+create = { kind = "merge", path = "~/dev/demo-repo/.claude/settings.json", body = "hook", event = "PreToolUse", command = "./scripts/audit.sh --event pre" }
+expect = { kind = "hook", install_method = "agent_artifact", config_scope = "project" }
+
+[[entries]]
+id = "S-15"
+name = "Local project hook"
+subcategory = "hook"
+platforms = ["mac", "linux", "win"]
+create = { kind = "merge", path = "~/dev/demo-repo/.claude/settings.local.json", body = "hook", event = "PostToolUse", command = "./scripts/audit.sh --event post" }
+expect = { kind = "hook", install_method = "agent_artifact", config_scope = "project" }
+
+# The hook whose command carries a credential. The asset must still be reported
+# - a redacted hook is reviewable, a missing hook is not - but the canary must
+# be absent from every byte of the serialized snapshot.
+
+[[entries]]
+id = "S-16"
+name = "Hook with a secret"
+subcategory = "hook"
+platforms = ["mac", "linux", "win"]
+canaries = ["hook_token"]
+create = { kind = "merge", path = "~/.claude/settings.json", body = "hook", event = "PreToolUse", command = "~/bin/audit.sh --token {{canary:hook_token}}" }
+expect = { kind = "hook", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-17"
+name = "Claude instructions"
+subcategory = "instructions"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.claude/CLAUDE.md", body = "instructions" }
+expect = { kind = "instructions", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-18"
+name = "Codex instructions"
+subcategory = "instructions"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.codex/AGENTS.md", body = "instructions" }
+expect = { kind = "instructions", install_method = "agent_artifact" }
+
+[[entries]]
+id = "S-19"
+name = "Gemini instructions"
+subcategory = "instructions"
+platforms = ["mac", "linux", "win"]
+create = { kind = "file", path = "~/.gemini/GEMINI.md", body = "instructions" }
+expect = { kind = "instructions", install_method = "agent_artifact" }

--- a/Discovery/tests/manifests/canaries.toml
+++ b/Discovery/tests/manifests/canaries.toml
@@ -1,0 +1,48 @@
+# The six planted credentials, declared by name and shape only.
+#
+# Values are generated per run and written to the run directory, never to git: a
+# credential checked into a repository is a credential, even a fake one, and a
+# scanner that flags it is not wrong to.
+#
+# Shapes matter because redaction is partly shape-driven. A canary that does not
+# look like the vendor's real token exercises a different code path from the one
+# that would leak in production, so each shape below mirrors a real format
+# closely enough to be recognized and never closely enough to be valid: every
+# prefix is followed by a marker no issuer emits.
+version = 1
+
+[[canaries]]
+name = "mcp_token"
+shape = "adr-e2e-canary-{random:32}"
+planted_by = "M-SP-03"
+surface = "argv"
+
+[[canaries]]
+name = "mcp_bearer"
+shape = "adr-e2e-canary-bearer-{random:32}"
+planted_by = "M-SP-04"
+surface = "http_header"
+
+[[canaries]]
+name = "mcp_env_anthropic"
+shape = "sk-ant-api03-ADRE2ECANARY{random:32}"
+planted_by = "M-SP-05"
+surface = "env_value"
+
+[[canaries]]
+name = "mcp_env_openai"
+shape = "sk-proj-ADRE2ECANARY{random:32}"
+planted_by = "M-SP-05"
+surface = "env_value"
+
+[[canaries]]
+name = "hook_token"
+shape = "adr-e2e-canary-hook-{random:32}"
+planted_by = "S-16"
+surface = "hook_command"
+
+[[canaries]]
+name = "env_key"
+shape = "sk-ant-api03-ADRE2ECANARY{random:32}"
+planted_by = "AG-12"
+surface = "shell_profile"

--- a/Discovery/tests/manifests/mcp.toml
+++ b/Discovery/tests/manifests/mcp.toml
@@ -1,0 +1,454 @@
+# Category 2 of Discovery/tests/README.md: the 29 MCP entries.
+#
+# MCP is the only purely *declared* surface - a server exists because a config
+# file says so, whether or not it has ever run. These entries need no installer
+# at all, which is why they are the first family the harness builds.
+#
+# Every M-SITE row declares the same trivial stdio server, so the only variable
+# is the site: a missed site shows up as a specific miss rather than as a lower
+# total. Every M-PIN row declares in ~/.claude.json, so the only variable is the
+# launch line. The repetition of `command`/`args` across the M-SITE rows is
+# therefore deliberate and must not be factored out.
+version = 1
+category = "mcp_server"
+
+# -- 2a. Declaration sites -- M-SITE-01 .. M-SITE-14 -------------------
+
+[[entries]]
+id = "M-SITE-01"
+name = "MCP server in Claude Code"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "adr-probe-cc"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/.claude.json", linux = "~/.claude.json", win = "%USERPROFILE%/.claude.json" }
+
+[[entries]]
+id = "M-SITE-02"
+name = "MCP server in Claude Desktop"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-01"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "claude-desktop"
+scope = "user"
+server_name = "adr-probe-cd"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/Library/Application Support/Claude/claude_desktop_config.json", linux = "~/.config/claude-desktop/claude_desktop_config.json", win = "%APPDATA%/Claude/claude_desktop_config.json" }
+
+[[entries]]
+id = "M-SITE-03"
+name = "MCP server in Cursor"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-02"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "cursor"
+scope = "user"
+server_name = "adr-probe-cursor"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/.cursor/mcp.json", linux = "~/.cursor/mcp.json", win = "%USERPROFILE%/.cursor/mcp.json" }
+
+[[entries]]
+id = "M-SITE-04"
+name = "MCP server in Windsurf"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-03"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "windsurf"
+scope = "user"
+server_name = "adr-probe-windsurf"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/.codeium/windsurf/mcp_config.json", linux = "~/.codeium/windsurf/mcp_config.json", win = "%APPDATA%/Codeium/windsurf/mcp_config.json" }
+
+[[entries]]
+id = "M-SITE-05"
+name = "MCP server in VS Code"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-04"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "vscode"
+scope = "user"
+server_name = "adr-probe-vscode"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/Library/Application Support/Code/User/mcp.json", linux = "~/.config/Code/User/mcp.json", win = "%APPDATA%/Code/User/mcp.json" }
+
+[[entries]]
+id = "M-SITE-06"
+name = "MCP server in Cline"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-EXT-01"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "cline"
+scope = "user"
+server_name = "adr-probe-cline"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json", linux = "~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json", win = "%APPDATA%/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json" }
+
+[[entries]]
+id = "M-SITE-07"
+name = "MCP server in Zed"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-05"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "zed"
+scope = "user"
+server_name = "adr-probe-zed"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/.config/zed/settings.json", linux = "~/.config/zed/settings.json", win = "%APPDATA%/Zed/settings.json" }
+
+[[entries]]
+id = "M-SITE-08"
+name = "MCP server in JetBrains"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-06"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "jetbrains"
+scope = "user"
+server_name = "adr-probe-jetbrains"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/Library/Application Support/JetBrains/options/mcp.json", linux = "~/.config/JetBrains/options/mcp.json", win = "%APPDATA%/JetBrains/options/mcp.json" }
+
+[[entries]]
+id = "M-SITE-09"
+name = "MCP server in opencode"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-CLI-04"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "opencode"
+scope = "user"
+server_name = "adr-probe-opencode"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/.config/opencode/opencode.json", linux = "~/.config/opencode/opencode.json", win = "%APPDATA%/opencode/opencode.json" }
+
+[[entries]]
+id = "M-SITE-10"
+name = "MCP server in Codex"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-CLI-02"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "codex"
+scope = "user"
+server_name = "adr-probe-codex"
+format = "toml"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/.codex/config.toml", linux = "~/.codex/config.toml", win = "%USERPROFILE%/.codex/config.toml" }
+
+[[entries]]
+id = "M-SITE-11"
+name = "MCP server in Goose"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-CLI-09"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "user" }
+[entries.declare]
+site = "goose"
+scope = "user"
+server_name = "adr-probe-goose"
+format = "yaml"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/.config/goose/config.yaml", linux = "~/.config/goose/config.yaml", win = "%APPDATA%/Block/goose/config/config.yaml" }
+
+# The two managed sites need root to write, and they are the reason the runner
+# keeps a privileged step: a policy file a user could write would not be policy.
+
+[[entries]]
+id = "M-SITE-12"
+name = "MCP server in Managed policy"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+privileged = true
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "enterprise_managed" }
+[entries.declare]
+site = "managed-claude-code"
+scope = "enterprise_managed"
+server_name = "adr-probe-managed"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "/Library/Application Support/ClaudeCode/managed-settings.json", linux = "/etc/claude-code/managed-settings.json", win = "C:/ProgramData/ClaudeCode/managed-settings.json" }
+
+[[entries]]
+id = "M-SITE-13"
+name = "MCP server in ADR policy"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+privileged = true
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "enterprise_managed" }
+[entries.declare]
+site = "managed-adr"
+scope = "enterprise_managed"
+server_name = "adr-probe-adr-policy"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "/Library/Application Support/ADR/managed-mcp.json", linux = "/etc/adr/managed-mcp.json", win = "C:/ProgramData/ADR/managed-mcp.json" }
+
+[[entries]]
+id = "M-SITE-14"
+name = "MCP server in a project checkout"
+subcategory = "mcp_site"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "stdio", config_scope = "project" }
+[entries.declare]
+site = "project"
+scope = "project"
+server_name = "adr-probe-project"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js"]
+path = { mac = "~/dev/demo-repo/.mcp.json", linux = "~/dev/demo-repo/.mcp.json", win = "%USERPROFILE%/dev/demo-repo/.mcp.json" }
+
+# -- 2b. Launch forms and the supply-chain verdict -- M-PIN-01 .. 09 ---
+# `pinned` is the field under test here, scored per entry rather than as an
+# aggregate: a collector that gets seven of nine right has a specific bug in
+# the two it misses, and an average would hide which two.
+
+[[entries]]
+id = "M-PIN-01"
+name = "filesystem server"
+subcategory = "mcp_launch"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "stdio", pinned = true }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "filesystem"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem@2025.8.21", "~/dev"]
+
+[[entries]]
+id = "M-PIN-02"
+name = "git server"
+subcategory = "mcp_launch"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "stdio", pinned = false }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "git"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-git"]
+
+[[entries]]
+id = "M-PIN-03"
+name = "github server"
+subcategory = "mcp_launch"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "stdio", pinned = true }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "github"
+command = "docker"
+args = ["run", "-i", "--rm", "ghcr.io/github/github-mcp-server:v0.5.0"]
+
+[[entries]]
+id = "M-PIN-04"
+name = "sqlite server"
+subcategory = "mcp_launch"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "stdio", pinned = true }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "sqlite"
+command = "uvx"
+args = ["mcp-server-sqlite@0.1.0", "--db-path", "~/dev/demo.db"]
+
+[[entries]]
+id = "M-PIN-05"
+name = "fetch server"
+subcategory = "mcp_launch"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "stdio", pinned = false }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "fetch"
+command = "uvx"
+args = ["mcp-server-fetch"]
+
+# `latest` is mutable, so it is a tag and not a version. A collector that reads
+# it as pinned has the most dangerous kind of wrong answer here.
+
+[[entries]]
+id = "M-PIN-06"
+name = "memory server"
+subcategory = "mcp_launch"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "stdio", pinned = false }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "memory"
+command = "docker"
+args = ["run", "-i", "--rm", "mcp/memory:latest"]
+
+[[entries]]
+id = "M-PIN-07"
+name = "playwright server"
+subcategory = "mcp_launch"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "stdio", pinned = false }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "playwright"
+command = "npx"
+args = ["@playwright/mcp@1.x"]
+
+[[entries]]
+id = "M-PIN-08"
+name = "local script server"
+subcategory = "mcp_launch"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "stdio", pinned = false }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "local-script"
+command = "node"
+args = ["~/dev/tools/my-server.js"]
+creates = ["~/dev/tools/my-server.js"]
+
+# Remote servers get no pinning verdict at all - there is no artifact whose
+# version could be pinned - so `pinned` is deliberately absent from `expect`
+# rather than set to either value.
+
+[[entries]]
+id = "M-PIN-09"
+name = "remote server"
+subcategory = "mcp_launch"
+platforms = ["mac", "linux", "win"]
+expect = { kind = "mcp_server", transport = "sse" }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "remote-sse"
+transport = "sse"
+url = "https://mcp.example.invalid/sse"
+
+# -- 2c. Special cases -- M-SP-01 .. M-SP-06 --------------------------
+
+# Started by hand, in no config at all. The asset is not the point; the
+# `undeclared_mcp_server` finding is.
+
+[[entries]]
+id = "M-SP-01"
+name = "Undeclared server"
+subcategory = "mcp_special"
+platforms = ["mac", "linux", "win"]
+install = { method = "service", source = "adr-probe-server", port = 39100 }
+expect = { kind = "mcp_server", finding = "undeclared_mcp_server" }
+
+# Same server in the managed site and the user site. Precedence says one asset,
+# scoped enterprise_managed - two assets here is a DUP, and a `user` scope is a
+# field failure that would misreport who controls the server.
+
+[[entries]]
+id = "M-SP-02"
+name = "Scope precedence"
+subcategory = "mcp_special"
+platforms = ["mac", "linux", "win"]
+depends_on = ["M-SITE-12", "M-SITE-01"]
+expect = { kind = "mcp_server", config_scope = "enterprise_managed" }
+[entries.declare]
+site = "both"
+sites = ["managed-claude-code", "claude-code"]
+scope = "enterprise_managed"
+server_name = "adr-probe-precedence"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js", "--precedence"]
+
+[[entries]]
+id = "M-SP-03"
+name = "Token in argv"
+subcategory = "mcp_special"
+platforms = ["mac", "linux", "win"]
+canaries = ["mcp_token"]
+expect = { kind = "mcp_server", transport = "stdio" }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "adr-probe-argv-token"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js", "--token", "{{canary:mcp_token}}"]
+
+[[entries]]
+id = "M-SP-04"
+name = "Auth header"
+subcategory = "mcp_special"
+platforms = ["mac", "linux", "win"]
+canaries = ["mcp_bearer"]
+expect = { kind = "mcp_server", transport = "sse" }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "adr-probe-auth-header"
+transport = "sse"
+url = "https://mcp.example.invalid/authed"
+headers = { Authorization = "Bearer {{canary:mcp_bearer}}" }
+
+# Two vendors' token shapes, because redaction is partly shape-driven and one
+# shape passing proves only that one shape passes.
+
+[[entries]]
+id = "M-SP-05"
+name = "Key in env"
+subcategory = "mcp_special"
+platforms = ["mac", "linux", "win"]
+canaries = ["mcp_env_anthropic", "mcp_env_openai"]
+expect = { kind = "mcp_server", transport = "stdio", env_names = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"] }
+[entries.declare]
+site = "claude-code"
+scope = "user"
+server_name = "adr-probe-env-key"
+command = "node"
+args = ["~/dev/tools/adr-probe-server.js", "--env-mode"]
+env = { ANTHROPIC_API_KEY = "{{canary:mcp_env_anthropic}}", OPENAI_API_KEY = "{{canary:mcp_env_openai}}" }
+
+# A bundle that declares nothing runnable must be recorded as malformed, not as
+# a server. Being confidently wrong and being silent are different failures, so
+# this one is scored as its own pass/fail rather than as a TP.
+
+[[entries]]
+id = "M-SP-06"
+name = "Malformed bundle"
+subcategory = "mcp_special"
+platforms = ["mac", "linux", "win"]
+must_not_be = "mcp_server"
+expect = { kind = "mcp_bundle", flags = ["malformed"] }
+[entries.create]
+kind = "file"
+format = "json"
+body = "malformed_bundle"
+path = { mac = "~/.mcpb/broken-bundle/manifest.json", linux = "~/.mcpb/broken-bundle/manifest.json", win = "%USERPROFILE%/.mcpb/broken-bundle/manifest.json" }

--- a/Discovery/tests/manifests/negative.toml
+++ b/Discovery/tests/manifests/negative.toml
@@ -1,0 +1,137 @@
+# Negative controls of Discovery/tests/README.md: N-01 .. N-10.
+#
+# Without these the false-positive rate cannot be measured, and a collector that
+# reported everything would score perfectly on every other table.
+#
+# `detect` is how the scorer attributes a false positive to the control that
+# provoked it. An FP matching none of these is still an FP - it is just an
+# unattributed one, which is the worse kind to receive.
+version = 1
+category = "negative_control"
+
+# N-01 .. N-04 are baseline: the golden image installs them because the rest of
+# the manifest depends on them. They are still scored, because "the
+# prerequisites are not AI tools" is exactly the claim that quietly stops being
+# true when a runtime starts shipping an assistant.
+
+[[entries]]
+id = "N-01"
+name = "Node.js"
+subcategory = "prerequisite"
+platforms = ["mac", "linux", "win"]
+must_not_appear = true
+reason = "a JavaScript runtime is not an AI tool"
+install = { method = "baseline-prereq", package = "nodejs" }
+detect = { names = ["node", "nodejs", "npm"], paths = ["/usr/bin/node", "/usr/local/bin/node"] }
+
+[[entries]]
+id = "N-02"
+name = "Python + pipx"
+subcategory = "prerequisite"
+platforms = ["mac", "linux", "win"]
+must_not_appear = true
+reason = "a language runtime and its installer are not AI tools"
+install = { method = "baseline-prereq", package = "python3-pipx" }
+detect = { names = ["python", "python3", "pipx"], paths = ["/usr/bin/python3", "/usr/local/bin/pipx"] }
+
+[[entries]]
+id = "N-03"
+name = "Docker"
+subcategory = "prerequisite"
+platforms = ["mac", "linux", "win"]
+must_not_appear = true
+reason = "a container runtime is not an AI tool, however many MCP servers run in it"
+install = { method = "baseline-prereq", package = "docker" }
+detect = { names = ["docker", "dockerd", "Docker Desktop"], paths = ["/usr/bin/docker"] }
+
+[[entries]]
+id = "N-04"
+name = "git"
+subcategory = "prerequisite"
+platforms = ["mac", "linux", "win"]
+must_not_appear = true
+reason = "version control is not an AI tool"
+install = { method = "baseline-prereq", package = "git" }
+detect = { names = ["git"], paths = ["/usr/bin/git"] }
+
+# A non-AI Electron app. Electron is the shape most AI desktop apps share, so a
+# collector that keys on the shape rather than on identity fails here.
+
+[[entries]]
+id = "N-05"
+name = "Slack desktop"
+subcategory = "non_ai_app"
+platforms = ["mac", "linux", "win"]
+must_not_appear = true
+reason = "an Electron app is not an AI app"
+install = { method = "non-ai-app", source = "slack" }
+detect = { names = ["Slack", "slack"], paths = ["/Applications/Slack.app", "/usr/share/slack"] }
+
+[[entries]]
+id = "N-06"
+name = "Prettier VS Code extension"
+subcategory = "non_ai_app"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-04"]
+must_not_appear = true
+reason = "a formatter extension is not an AI extension"
+install = { method = "non-ai-app", extension_id = "esbenp.prettier-vscode" }
+detect = { names = ["prettier", "esbenp.prettier-vscode"] }
+
+# A path that contains "mcp" and nothing else that does. Substring matching on a
+# path is the cheapest possible MCP detector and the wrongest.
+
+[[entries]]
+id = "N-07"
+name = "mcp-backup.sh"
+subcategory = "lookalike"
+platforms = ["mac", "linux", "win"]
+must_not_appear = true
+reason = "a path containing \"mcp\" is not an MCP server"
+create = { kind = "file", path = "~/bin/mcp-backup.sh", body = "backup_script", mode = "0755" }
+detect = { names = ["mcp-backup", "mcp-backup.sh"], paths = ["~/bin/mcp-backup.sh"] }
+
+# An HTTP server on a plausible port serving JSON that is not a model list.
+# Port-plus-JSON is the other cheap detector, and this is where it fails.
+
+[[entries]]
+id = "N-08"
+name = "nginx serving non-model JSON"
+subcategory = "lookalike"
+platforms = ["mac", "linux", "win"]
+must_not_appear = true
+reason = "a listening port serving JSON is not a model runtime"
+install = { method = "service", source = "nginx", port = 8081, health = "/status.json" }
+detect = { names = ["nginx"], ports = [8081] }
+
+# A dangling symlink named after a real tool. The target does not exist, so
+# nothing is installed - and an asset here means the collector believes a name
+# rather than a file.
+
+[[entries]]
+id = "N-09"
+name = "Dangling claude symlink"
+subcategory = "lookalike"
+platforms = ["mac", "linux", "win"]
+privileged = true
+must_not_appear = true
+explains_error = true
+reason = "a symlink to a missing target is not an installed tool"
+create = { kind = "symlink", path = "/usr/local/bin/claude-old", target = "/opt/removed/claude", mode = "0777" }
+detect = { paths = ["/usr/local/bin/claude-old", "/opt/removed/claude"] }
+
+# The open-world check. Unlike every other control this one must not be silent
+# either: an unrecognized tool that looks like AI belongs in review_queue.
+# Confidently wrong and silent are different failures, and this entry is scored
+# against both.
+
+[[entries]]
+id = "N-10"
+name = "In-house AI wrapper"
+subcategory = "open_world"
+platforms = ["mac", "linux", "win"]
+must_not_appear = true
+must_be_reviewed = true
+reason = "an uncatalogued AI wrapper belongs in review_queue, not in assets"
+create = { kind = "file", path = "~/bin/ask-corp-llm.sh", body = "llm_wrapper", mode = "0755" }
+detect = { names = ["ask-corp-llm", "ask-corp-llm.sh"], paths = ["~/bin/ask-corp-llm.sh"] }

--- a/Discovery/tests/manifests/sources.toml
+++ b/Discovery/tests/manifests/sources.toml
@@ -1,0 +1,156 @@
+# Where the vendor-installed entries come from, per OS.
+#
+# Kept out of the entry rows because these are the volatile part of the
+# manifest: sixteen vendors, sixteen sets of silent-install flags, and sixteen
+# habits of changing both. Separating them means a URL rotation is a one-line
+# diff to this file rather than an edit to the inventory.
+#
+# `url = ""` means unresolved. The app-installer and vendor-binary recipes
+# refuse to run an entry whose source is unresolved and record it
+# `unimplemented` rather than `failed`, because a URL nobody has filled in is a
+# harness gap and must never be reported as a vendor that stopped shipping.
+# `adr-e2e check` lists what is still empty.
+version = 1
+
+# -- vendor binaries (T-CLI-11, T-CLI-12) ------------------------------
+[sources.crush]
+mac = { type = "tarball", url = "" }
+linux = { type = "tarball", url = "" }
+win = { type = "zip", url = "" }
+
+[sources.grok-cli]
+mac = { type = "tarball", url = "" }
+linux = { type = "tarball", url = "" }
+win = { type = "zip", url = "" }
+
+# -- desktop apps and browsers (T-APP-01 .. T-APP-16) ------------------
+# `silent` is the flag set that makes the installer run unattended. An empty
+# string is not a default: it means nobody has confirmed the flags yet.
+[sources.claude-desktop]
+mac = { type = "dmg", url = "", silent = "" }
+win = { type = "exe", url = "", silent = "/S" }
+
+[sources.cursor]
+mac = { type = "dmg", url = "", silent = "" }
+linux = { type = "deb", url = "", silent = "" }
+win = { type = "exe", url = "", silent = "/VERYSILENT /MERGETASKS=!runcode" }
+
+[sources.windsurf]
+mac = { type = "dmg", url = "", silent = "" }
+linux = { type = "deb", url = "", silent = "" }
+win = { type = "exe", url = "", silent = "/VERYSILENT" }
+
+[sources.vscode]
+mac = { type = "zip", url = "", silent = "" }
+linux = { type = "deb", url = "", silent = "" }
+win = { type = "exe", url = "", silent = "/VERYSILENT /MERGETASKS=!runcode" }
+
+[sources.zed]
+mac = { type = "dmg", url = "", silent = "" }
+linux = { type = "tarball", url = "", silent = "" }
+
+[sources.jetbrains-ai]
+mac = { type = "dmg", url = "", silent = "" }
+linux = { type = "tarball", url = "", silent = "" }
+win = { type = "exe", url = "", silent = "/S" }
+
+[sources.trae]
+mac = { type = "dmg", url = "", silent = "" }
+win = { type = "exe", url = "", silent = "/VERYSILENT" }
+
+[sources.warp]
+mac = { type = "dmg", url = "", silent = "" }
+linux = { type = "deb", url = "", silent = "" }
+win = { type = "exe", url = "", silent = "/VERYSILENT" }
+
+[sources.chatgpt-desktop]
+mac = { type = "dmg", url = "", silent = "" }
+win = { type = "msix", url = "", silent = "" }
+
+[sources.perplexity]
+mac = { type = "dmg", url = "", silent = "" }
+
+[sources.gemini-desktop]
+mac = { type = "dmg", url = "", silent = "" }
+win = { type = "exe", url = "", silent = "/S" }
+
+[sources.copilot-desktop]
+mac = { type = "dmg", url = "", silent = "" }
+win = { type = "msix", url = "", silent = "" }
+
+[sources.raycast]
+mac = { type = "dmg", url = "", silent = "" }
+
+[sources.comet]
+mac = { type = "dmg", url = "", silent = "" }
+win = { type = "exe", url = "", silent = "/S" }
+
+[sources.dia]
+mac = { type = "dmg", url = "", silent = "" }
+
+[sources.atlas]
+mac = { type = "dmg", url = "", silent = "" }
+
+# -- services (T-RT-*, M-SP-01, N-08) ---------------------------------
+# Model weights are baked into the golden image rather than pulled per run: a
+# run that downloads gigabytes is a run that fails the day a registry
+# rate-limits it, and that failure would read as a detection regression.
+[sources.ollama]
+mac = { type = "dmg", url = "" }
+linux = { type = "script", url = "" }
+win = { type = "exe", url = "", silent = "/S" }
+
+[sources.lm-studio]
+mac = { type = "dmg", url = "" }
+linux = { type = "appimage", url = "" }
+win = { type = "exe", url = "", silent = "/S" }
+
+[sources."llama.cpp"]
+mac = { type = "brew", package = "llama.cpp" }
+linux = { type = "tarball", url = "" }
+win = { type = "zip", url = "" }
+
+[sources.gpt4all]
+mac = { type = "dmg", url = "" }
+linux = { type = "run", url = "" }
+win = { type = "exe", url = "", silent = "/S" }
+
+[sources.jan]
+mac = { type = "dmg", url = "" }
+linux = { type = "appimage", url = "" }
+win = { type = "exe", url = "", silent = "/S" }
+
+[sources.vllm]
+linux = { type = "pip", package = "vllm", requires = "gpu" }
+
+[sources.localai]
+mac = { type = "brew", package = "localai" }
+linux = { type = "docker", image = "localai/localai:latest" }
+
+[sources.open-webui]
+mac = { type = "pip", package = "open-webui" }
+linux = { type = "docker", image = "ghcr.io/open-webui/open-webui:main" }
+win = { type = "pip", package = "open-webui" }
+
+[sources.openhands]
+mac = { type = "docker", image = "docker.all-hands.dev/all-hands-ai/openhands:latest" }
+linux = { type = "docker", image = "docker.all-hands.dev/all-hands-ai/openhands:latest" }
+win = { type = "docker", image = "docker.all-hands.dev/all-hands-ai/openhands:latest" }
+
+# The trivial stdio MCP server M-SP-01 starts by hand and every M-SITE row
+# declares. Written by the harness, so it has no URL to resolve.
+[sources.adr-probe-server]
+mac = { type = "local", path = "~/dev/tools/adr-probe-server.js" }
+linux = { type = "local", path = "~/dev/tools/adr-probe-server.js" }
+win = { type = "local", path = "~/dev/tools/adr-probe-server.js" }
+
+# -- negative controls that need an installer (N-05, N-08) -------------
+[sources.slack]
+mac = { type = "dmg", url = "", silent = "" }
+linux = { type = "deb", url = "", silent = "" }
+win = { type = "exe", url = "", silent = "/S" }
+
+[sources.nginx]
+mac = { type = "brew", package = "nginx" }
+linux = { type = "apt", package = "nginx" }
+win = { type = "zip", url = "" }

--- a/Discovery/tests/manifests/tools.toml
+++ b/Discovery/tests/manifests/tools.toml
@@ -1,0 +1,520 @@
+# Category 1 of Discovery/tests/README.md: the 50 AI-tool entries.
+#
+# Versions are pinned because an unpinned install makes the expected `version`
+# unscoreable - the correct answer becomes whatever the registry served that
+# morning. The pins below are the reviewed set for the current golden images;
+# bumping one is a manifest change like any other. `pins_confirmed` stays false
+# until somebody has checked each against the registry it installs from, and
+# `adr-e2e check` reports that state rather than assuming it.
+version = 1
+category = "ai_tool"
+# npm pins below were confirmed against registry.npmjs.org on 2026-08-22 and
+# proved by a live install; the pipx and vscode-ext pins have not been.
+pins_confirmed = false
+
+# -- 1a. CLI coding agents -- T-CLI-01 .. T-CLI-12 ----------------------
+# Installed globally so their binaries land on PATH. One asset each, with a
+# correct version, a real install_path, and the channel they arrived through.
+
+[[entries]]
+id = "T-CLI-01"
+name = "Claude Code"
+subcategory = "cli_agent"
+catalog_id = "claude-code"
+platforms = ["mac", "linux", "win"]
+verify = "claude --version"
+install = { method = "npm-global", package = "@anthropic-ai/claude-code", version = "2.1.235", binary = "claude" }
+expect = { kind = "cli_agent", install_method = "npm", liveness = "installed" }
+
+[[entries]]
+id = "T-CLI-02"
+name = "Codex CLI"
+subcategory = "cli_agent"
+catalog_id = "codex"
+platforms = ["mac", "linux", "win"]
+verify = "codex --version"
+install = { method = "npm-global", package = "@openai/codex", version = "0.58.0", binary = "codex" }
+expect = { kind = "cli_agent", install_method = "npm", liveness = "installed" }
+
+[[entries]]
+id = "T-CLI-03"
+name = "Gemini CLI"
+subcategory = "cli_agent"
+catalog_id = "gemini-cli"
+platforms = ["mac", "linux", "win"]
+verify = "gemini --version"
+install = { method = "npm-global", package = "@google/gemini-cli", version = "0.12.0", binary = "gemini" }
+expect = { kind = "cli_agent", install_method = "npm", liveness = "installed" }
+
+[[entries]]
+id = "T-CLI-04"
+name = "opencode"
+subcategory = "cli_agent"
+catalog_id = "opencode"
+platforms = ["mac", "linux", "win"]
+verify = "opencode --version"
+install = { method = "npm-global", package = "opencode-ai", version = "0.5.29", binary = "opencode" }
+expect = { kind = "cli_agent", install_method = "npm", liveness = "installed" }
+
+[[entries]]
+id = "T-CLI-05"
+name = "Amp"
+subcategory = "cli_agent"
+catalog_id = "amp"
+platforms = ["mac", "linux", "win"]
+verify = "amp --version"
+install = { method = "npm-global", package = "@sourcegraph/amp", version = "0.0.1787428878-gebb20a", binary = "amp" }
+expect = { kind = "cli_agent", install_method = "npm", liveness = "installed" }
+
+[[entries]]
+id = "T-CLI-06"
+name = "Kilo CLI"
+subcategory = "cli_agent"
+catalog_id = "kilo-cli"
+platforms = ["mac", "linux", "win"]
+verify = "kilo --version"
+install = { method = "npm-global", package = "@kilocode/cli", version = "7.4.23", binary = "kilo" }
+expect = { kind = "cli_agent", install_method = "npm", liveness = "installed" }
+
+[[entries]]
+id = "T-CLI-07"
+name = "Qwen Code"
+subcategory = "cli_agent"
+catalog_id = "qwen-code"
+platforms = ["mac", "linux", "win"]
+verify = "qwen --version"
+install = { method = "npm-global", package = "@qwen-code/qwen-code", version = "0.22.0", binary = "qwen" }
+expect = { kind = "cli_agent", install_method = "npm", liveness = "installed" }
+
+[[entries]]
+id = "T-CLI-08"
+name = "Copilot CLI"
+subcategory = "cli_agent"
+catalog_id = "copilot-cli"
+platforms = ["mac", "linux", "win"]
+verify = "copilot --version"
+install = { method = "npm-global", package = "@github/copilot", version = "1.0.80", binary = "copilot" }
+expect = { kind = "cli_agent", install_method = "npm", liveness = "installed" }
+
+# The spec's `npm i -g @block/goose-cli` does not resolve: the scope does not
+# exist on the registry. The obvious substitute is worse than nothing - the
+# unscoped `goose-cli` on npm is a wrapper around the *database migration* tool
+# of the same name, so installing it would put an unrelated binary called
+# `goose` on PATH and the harness would record a successful install of the wrong
+# product. Left unresolved on purpose until somebody confirms how Block ships
+# it, and recorded `unimplemented` rather than `failed` in the meantime.
+[[entries]]
+id = "T-CLI-09"
+name = "Goose"
+subcategory = "cli_agent"
+catalog_id = "goose"
+platforms = ["mac", "linux", "win"]
+verify = "goose --version"
+install = { method = "npm-global", package = "@block/goose-cli", version = "1.0.28", binary = "goose", unresolved = "package not on the registry; see comment" }
+expect = { kind = "cli_agent", install_method = "npm", liveness = "installed" }
+
+[[entries]]
+id = "T-CLI-10"
+name = "Aider"
+subcategory = "cli_agent"
+catalog_id = "aider"
+platforms = ["mac", "linux", "win"]
+verify = "aider --version"
+install = { method = "pipx", package = "aider-chat", version = "0.86.1", binary = "aider" }
+expect = { kind = "cli_agent", install_method = "pipx", liveness = "installed" }
+
+# A binary dropped on PATH carries no channel marker, so `unknown` is the
+# correct expectation rather than a gap: claiming a channel we cannot see would
+# send a remediation to a package manager that never installed it.
+
+[[entries]]
+id = "T-CLI-11"
+name = "Crush"
+subcategory = "cli_agent"
+catalog_id = "crush"
+platforms = ["mac", "linux", "win"]
+verify = "crush --version"
+install = { method = "vendor-binary", source = "crush", dest = "/usr/local/bin/crush", binary = "crush" }
+expect = { kind = "cli_agent", install_method = "unknown", liveness = "installed" }
+
+[[entries]]
+id = "T-CLI-12"
+name = "Grok CLI"
+subcategory = "cli_agent"
+catalog_id = "grok-cli"
+platforms = ["mac", "linux", "win"]
+verify = "grok --version"
+install = { method = "vendor-binary", source = "grok-cli", dest = "/usr/local/bin/grok", binary = "grok" }
+expect = { kind = "cli_agent", install_method = "unknown", liveness = "installed" }
+
+# -- 1b. Desktop apps, IDEs and AI browsers -- T-APP-01 .. T-APP-16 -----
+# Vendor installers, so the real bundle, registry entry or .desktop file
+# exists. Every one of these needs a logged-in graphical session on the VM.
+# Download URLs and silent flags live in sources.toml, per OS.
+
+[[entries]]
+id = "T-APP-01"
+name = "Claude Desktop"
+subcategory = "app"
+catalog_id = "claude-desktop"
+platforms = ["mac", "win"]
+install = { method = "app-installer", source = "claude-desktop" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-02"
+name = "Cursor"
+subcategory = "app"
+catalog_id = "cursor"
+platforms = ["mac", "linux", "win"]
+install = { method = "app-installer", source = "cursor" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-03"
+name = "Windsurf"
+subcategory = "app"
+catalog_id = "windsurf"
+platforms = ["mac", "linux", "win"]
+install = { method = "app-installer", source = "windsurf" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-04"
+name = "VS Code"
+subcategory = "app"
+catalog_id = "vscode"
+platforms = ["mac", "linux", "win"]
+install = { method = "app-installer", source = "vscode" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-05"
+name = "Zed"
+subcategory = "app"
+catalog_id = "zed"
+platforms = ["mac", "linux"]
+install = { method = "app-installer", source = "zed" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-06"
+name = "JetBrains IDE + AI Assistant"
+subcategory = "app"
+catalog_id = "jetbrains-ai"
+platforms = ["mac", "linux", "win"]
+install = { method = "app-installer", source = "jetbrains-ai" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-07"
+name = "Trae"
+subcategory = "app"
+catalog_id = "trae"
+platforms = ["mac", "win"]
+install = { method = "app-installer", source = "trae" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-08"
+name = "Warp"
+subcategory = "app"
+catalog_id = "warp"
+platforms = ["mac", "linux", "win"]
+install = { method = "app-installer", source = "warp" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-09"
+name = "ChatGPT Desktop"
+subcategory = "app"
+catalog_id = "chatgpt-desktop"
+platforms = ["mac", "win"]
+install = { method = "app-installer", source = "chatgpt-desktop" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-10"
+name = "Perplexity"
+subcategory = "app"
+catalog_id = "perplexity"
+platforms = ["mac"]
+install = { method = "app-installer", source = "perplexity" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-11"
+name = "Gemini Desktop"
+subcategory = "app"
+catalog_id = "gemini-desktop"
+platforms = ["mac", "win"]
+install = { method = "app-installer", source = "gemini-desktop" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-12"
+name = "Copilot Desktop"
+subcategory = "app"
+catalog_id = "copilot-desktop"
+platforms = ["mac", "win"]
+install = { method = "app-installer", source = "copilot-desktop" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-13"
+name = "Raycast"
+subcategory = "app"
+catalog_id = "raycast"
+platforms = ["mac"]
+install = { method = "app-installer", source = "raycast" }
+expect = { kind = "app", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-14"
+name = "Comet browser"
+subcategory = "app"
+catalog_id = "comet"
+platforms = ["mac", "win"]
+install = { method = "app-installer", source = "comet" }
+expect = { kind = "ai_browser", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-15"
+name = "Dia browser"
+subcategory = "app"
+catalog_id = "dia"
+platforms = ["mac"]
+install = { method = "app-installer", source = "dia" }
+expect = { kind = "ai_browser", liveness = "installed" }
+
+[[entries]]
+id = "T-APP-16"
+name = "ChatGPT Atlas"
+subcategory = "app"
+catalog_id = "atlas"
+platforms = ["mac"]
+install = { method = "app-installer", source = "atlas" }
+expect = { kind = "ai_browser", liveness = "installed" }
+
+# -- 1c. IDE extensions -- T-EXT-01 .. T-EXT-05 ------------------------
+# Installed into the VS Code from T-APP-04, which is why the runner orders
+# app-installer ahead of vscode-ext rather than following manifest order.
+
+[[entries]]
+id = "T-EXT-01"
+name = "Cline"
+subcategory = "extension"
+catalog_id = "cline"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-04"]
+install = { method = "vscode-ext", extension_id = "saoudrizwan.claude-dev", version = "3.42.0" }
+expect = { kind = "extension", install_method = "ide_extension", liveness = "installed" }
+
+[[entries]]
+id = "T-EXT-02"
+name = "Continue"
+subcategory = "extension"
+catalog_id = "continue"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-04"]
+install = { method = "vscode-ext", extension_id = "continue.continue", version = "1.5.9" }
+expect = { kind = "extension", install_method = "ide_extension", liveness = "installed" }
+
+[[entries]]
+id = "T-EXT-03"
+name = "Roo Code"
+subcategory = "extension"
+catalog_id = "roo-code"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-04"]
+install = { method = "vscode-ext", extension_id = "rooveterinaryinc.roo-cline", version = "3.30.1" }
+expect = { kind = "extension", install_method = "ide_extension", liveness = "installed" }
+
+[[entries]]
+id = "T-EXT-04"
+name = "Kilo Code"
+subcategory = "extension"
+catalog_id = "kilo-code"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-04"]
+install = { method = "vscode-ext", extension_id = "kilocode.kilo-code", version = "4.108.0" }
+expect = { kind = "extension", install_method = "ide_extension", liveness = "installed" }
+
+[[entries]]
+id = "T-EXT-05"
+name = "GitHub Copilot"
+subcategory = "extension"
+catalog_id = "copilot-ext"
+platforms = ["mac", "linux", "win"]
+depends_on = ["T-APP-04"]
+install = { method = "vscode-ext", extension_id = "github.copilot", version = "1.380.0" }
+expect = { kind = "extension", install_method = "ide_extension", liveness = "installed" }
+
+# -- 1d. Local model runtimes -- T-RT-01 .. T-RT-09 --------------------
+# Installed *and started*, with a small model pulled, so the listening port and
+# the model-listing endpoint are both real. T-RT-03 and T-RT-07 both default to
+# 8080; the manifest assigns distinct ports so a collision can never masquerade
+# as a detection failure.
+
+[[entries]]
+id = "T-RT-01"
+name = "Ollama"
+subcategory = "model_runtime"
+catalog_id = "ollama"
+platforms = ["mac", "linux", "win"]
+install = { method = "service", source = "ollama", port = 11434, health = "/api/tags", model = "qwen2.5:0.5b" }
+expect = { kind = "model_runtime", liveness = "running" }
+
+[[entries]]
+id = "T-RT-02"
+name = "LM Studio"
+subcategory = "model_runtime"
+catalog_id = "lm-studio"
+platforms = ["mac", "linux", "win"]
+install = { method = "service", source = "lm-studio", port = 1234, health = "/v1/models", model = "qwen2.5-0.5b-gguf" }
+expect = { kind = "model_runtime", liveness = "running" }
+
+[[entries]]
+id = "T-RT-03"
+name = "llama.cpp"
+subcategory = "model_runtime"
+catalog_id = "llama.cpp"
+platforms = ["mac", "linux", "win"]
+install = { method = "service", source = "llama.cpp", port = 8080, health = "/v1/models", model = "qwen2.5-0.5b-gguf" }
+expect = { kind = "model_runtime", liveness = "running" }
+
+[[entries]]
+id = "T-RT-04"
+name = "GPT4All"
+subcategory = "model_runtime"
+catalog_id = "gpt4all"
+platforms = ["mac", "linux", "win"]
+install = { method = "service", source = "gpt4all", model = "bundled" }
+expect = { kind = "model_runtime", liveness = "installed" }
+
+[[entries]]
+id = "T-RT-05"
+name = "Jan"
+subcategory = "model_runtime"
+catalog_id = "jan"
+platforms = ["mac", "linux", "win"]
+install = { method = "service", source = "jan", port = 1337, health = "/v1/models", model = "any-small" }
+expect = { kind = "model_runtime", liveness = "running" }
+
+# The one entry no macOS or Windows guest can satisfy: it wants a CUDA GPU.
+# Recorded `unavailable` there rather than scored as a miss.
+
+[[entries]]
+id = "T-RT-06"
+name = "vLLM"
+subcategory = "model_runtime"
+catalog_id = "vllm"
+platforms = ["linux"]
+install = { method = "service", source = "vllm", port = 8000, health = "/v1/models", requires = "gpu" }
+expect = { kind = "model_runtime", liveness = "running" }
+
+[[entries]]
+id = "T-RT-07"
+name = "LocalAI"
+subcategory = "model_runtime"
+catalog_id = "localai"
+platforms = ["mac", "linux"]
+install = { method = "service", source = "localai", port = 8082, health = "/v1/models", model = "any-small" }
+expect = { kind = "model_runtime", liveness = "running" }
+
+[[entries]]
+id = "T-RT-08"
+name = "Open WebUI"
+subcategory = "model_runtime"
+catalog_id = "open-webui"
+platforms = ["mac", "linux", "win"]
+install = { method = "service", source = "open-webui", port = 8083, health = "/" }
+expect = { kind = "ai_frontend", liveness = "running" }
+
+[[entries]]
+id = "T-RT-09"
+name = "OpenHands"
+subcategory = "model_runtime"
+catalog_id = "openhands"
+platforms = ["mac", "linux", "win"]
+install = { method = "service", source = "openhands" }
+expect = { kind = "agent_platform", liveness = "installed" }
+
+# -- 1e. Install-channel variants -- T-CHAN-01 .. T-CHAN-08 ------------
+# Deliberate second installs of a tool already listed above. These are not
+# scored for presence - the base entry covers that - but for duplication: one
+# tool reached two ways must still resolve to one asset. This is the defect
+# class that has broken most often, which is why it has its own outcome (DUP)
+# rather than being folded into a partial success.
+
+[[entries]]
+id = "T-CHAN-01"
+name = "Claude Code under an nvm-managed Node"
+subcategory = "channel_variant"
+platforms = ["linux"]
+variant_of = "T-CLI-01"
+asserts = "version-manager Node roots resolve to one asset"
+install = { method = "channel-variant", variant = "nvm", package = "@anthropic-ai/claude-code" }
+
+[[entries]]
+id = "T-CHAN-02"
+name = "Claude Code under an fnm-managed Node"
+subcategory = "channel_variant"
+platforms = ["mac"]
+variant_of = "T-CLI-01"
+asserts = "as T-CHAN-01, second manager"
+install = { method = "channel-variant", variant = "fnm", package = "@anthropic-ai/claude-code" }
+
+[[entries]]
+id = "T-CHAN-03"
+name = "Codex installed to ~/.local/bin"
+subcategory = "channel_variant"
+platforms = ["linux"]
+variant_of = "T-CLI-02"
+asserts = "user-local install does not double-count"
+install = { method = "channel-variant", variant = "user-local", package = "@openai/codex" }
+
+[[entries]]
+id = "T-CHAN-04"
+name = "Claude Code reachable via both /usr/bin and /bin"
+subcategory = "channel_variant"
+platforms = ["linux"]
+variant_of = "T-CLI-01"
+asserts = "usr-merge: two spellings, one asset, canonical path reported"
+install = { method = "channel-variant", variant = "usr-merge" }
+
+[[entries]]
+id = "T-CHAN-05"
+name = "Aider via pip --user alongside pipx"
+subcategory = "channel_variant"
+platforms = ["mac"]
+variant_of = "T-CLI-10"
+asserts = "two Python channels, one asset"
+install = { method = "channel-variant", variant = "pip-user", package = "aider-chat" }
+
+[[entries]]
+id = "T-CHAN-06"
+name = "Ollama via distro package and vendor script"
+subcategory = "channel_variant"
+platforms = ["linux"]
+variant_of = "T-RT-01"
+asserts = "two package channels, one asset"
+install = { method = "channel-variant", variant = "distro-and-vendor", source = "ollama" }
+
+[[entries]]
+id = "T-CHAN-07"
+name = "Cursor via .deb and AppImage"
+subcategory = "channel_variant"
+platforms = ["linux"]
+variant_of = "T-APP-02"
+asserts = "two app channels, one asset"
+install = { method = "channel-variant", variant = "deb-and-appimage", source = "cursor" }
+
+[[entries]]
+id = "T-CHAN-08"
+name = "VS Code via winget and vendor .exe"
+subcategory = "channel_variant"
+platforms = ["win"]
+variant_of = "T-APP-04"
+asserts = "casing and registry vs filesystem agree"
+install = { method = "channel-variant", variant = "winget-and-exe", source = "vscode" }

--- a/Discovery/tests/test_manifest.py
+++ b/Discovery/tests/test_manifest.py
@@ -1,0 +1,73 @@
+"""The manifest is a specification, so its shape is asserted like one."""
+
+import unittest
+
+from . import manifest as manifest_module
+
+
+class ManifestShape(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+
+    def test_the_manifest_is_complete(self):
+        """120 entries. An entry not listed is an entry not tested."""
+        self.assertEqual(len(self.manifest), 120)
+
+    def test_applicable_counts_per_os(self):
+        """Denominators differ per OS, which is why recall is never pooled."""
+        self.assertEqual(len(self.manifest.for_platform("mac")), 110)
+        self.assertEqual(len(self.manifest.for_platform("linux")), 105)
+        self.assertEqual(len(self.manifest.for_platform("win")), 103)
+
+    def test_fourteen_families_cover_everything(self):
+        counts = {}
+        for entry in self.manifest:
+            counts[entry.family] = counts.get(entry.family, 0) + 1
+        self.assertEqual(sum(counts.values()), 120)
+        self.assertLessEqual(set(counts), manifest_module.FAMILIES)
+        self.assertEqual(counts["declare-mcp"], 27)
+        self.assertEqual(counts["artifact"], 24)
+        self.assertEqual(counts["app-installer"], 16)
+
+    def test_half_the_manifest_needs_no_installer(self):
+        """The property the build order depends on: 51 entries are file writes."""
+        no_installer = [entry for entry in self.manifest
+                        if entry.family in ("declare-mcp", "artifact")]
+        self.assertEqual(len(no_installer), 51)
+
+    def test_every_catalogued_tool_appears_once(self):
+        seen = {}
+        for entry in self.manifest:
+            if entry.catalog_id:
+                seen[entry.catalog_id] = seen.get(entry.catalog_id, 0) + 1
+        self.assertEqual([k for k, v in seen.items() if v > 1], [])
+        self.assertEqual(len(seen), 42)
+
+    def test_installed_packages_are_pinned(self):
+        """An unpinned install makes `version` unscoreable."""
+        for entry in self.manifest:
+            if entry.family in ("npm-global", "pipx", "vscode-ext"):
+                self.assertTrue(entry.install.get("version"), entry.id)
+
+    def test_variants_name_a_base_that_applies_there(self):
+        for entry in self.manifest:
+            if not entry.variant_of:
+                continue
+            base = self.manifest.by_id(entry.variant_of)
+            for platform in entry.platforms:
+                self.assertTrue(base.applies_to(platform), "%s on %s" % (entry.id, platform))
+
+    def test_shapes_are_derived_not_declared(self):
+        shapes = {entry.shape for entry in self.manifest}
+        self.assertEqual(shapes, {"install", "declare", "create", "state"})
+
+
+class ManifestValidation(unittest.TestCase):
+    def test_a_bad_family_is_refused_at_load(self):
+        with self.assertRaises(manifest_module.ManifestError):
+            manifest_module._family({"id": "X-01", "install": {"method": "telepathy"}})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First of a stacked series building the end-to-end harness specified in `Discovery/tests/README.md`. This one is the inventory itself — the part that most needs domain review, which is why it lands alone rather than under several thousand lines of Python.

## What this is

The 120 rows of the test plan, as data the harness can execute. Each entry carries a stable id, the platforms it applies to, how it arrives on a machine, and what the collector is expected to report about it.

```
manifests/tools.toml       50   T-CLI, T-APP, T-EXT, T-RT, T-CHAN
manifests/mcp.toml         29   M-SITE, M-PIN, M-SP
manifests/artifacts.toml   19   S-01 … S-19
manifests/agents.toml      12   AG-01 … AG-12
manifests/negative.toml    10   N-01 … N-10
manifests/canaries.toml     6   credentials, by shape - never by value
manifests/sources.toml     30   vendor urls and silent flags, per OS
```

`manifest.py` is the only reader of those files. Everything downstream works on `Entry` objects, so a format change touches one file.

## Two decisions worth reviewing

**TOML, not YAML.** The manifest is reviewed like code and the reasoning beside an entry is most of its value, so the format has to keep comments. TOML also parses with `tomllib` from the standard library, which is what lets the harness run from the test directory with nothing installed.

**The recipe family is derived, not declared.** A row that said `family = "artifact"` while carrying an `install` block would be executed one way and reported another. The block *is* the declaration.

## Numbers that should match the plan

| | mac | linux | win |
|---|---:|---:|---:|
| applicable entries | 110 | 105 | 103 |

All 42 catalog ids have exactly one row. 51 entries — `declare-mcp` and `artifact` — need no installer at all, which is what makes an early automated run substantial rather than a token slice.

## Verification

```
$ python3 -m unittest discover -s tests -t . -q
Ran 9 tests in 0.004s
OK
```

Nine tests cover the counts, the per-OS denominators, the family totals, and the load-time rules. The three CI-facing checks — catalog coverage, id contiguity, canary declaration — arrive in the next PR with the workflow job that runs them.