### PR TITLE
test(discovery): match manifest entries to reported assets

### DIFF
--- a/Discovery/tests/scoring/__init__.py
+++ b/Discovery/tests/scoring/__init__.py
@@ -5,6 +5,7 @@ any VM exists, replayed against every recorded run after a change, and reasoned
 about by somebody who has never provisioned a guest.
 """
 
+from .match import load_snapshot, match_all
 from .snapshot import Asset, Snapshot, added_assets, duplicate_ids
 
-__all__ = ["Asset", "Snapshot", "added_assets", "duplicate_ids"]
+__all__ = ["Asset", "Snapshot", "added_assets", "duplicate_ids", "load_snapshot", "match_all"]

--- a/Discovery/tests/scoring/match.py
+++ b/Discovery/tests/scoring/match.py
@@ -1,0 +1,365 @@
+"""Matching reported assets to manifest entries.
+
+The join is by entry *shape*, not by category: an installed tool is matched by
+catalog id, a declared server by what it launches, an artifact by its path, and
+a state by the asset it attaches to. Getting this wrong in either direction is
+expensive - a missed join reads as a miss the collector never made, and a loose
+join hides a real one - so every rule here is deliberately narrow and every
+fallback is explicit.
+
+Nothing in this module imports a probe. The collector is a black box; the only
+things read are its published snapshot and its published diff.
+"""
+
+import posixpath
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from ..manifest import Entry, Manifest
+from .snapshot import Asset, Snapshot
+
+#: What the collector writes in place of a value it refused to keep. Treated as
+#: a wildcard when comparing a launch line, because the manifest holds the
+#: plaintext the config was written with and the snapshot never will.
+REDACTED = "[REDACTED]"
+
+def load_snapshot(source: Any) -> Snapshot:
+    """Read a snapshot the collector wrote. See :mod:`.snapshot` for why the
+    harness models the format rather than importing it."""
+    return Snapshot.load(source)
+
+
+# -- normalization -----------------------------------------------------
+
+
+def expand(path: Optional[str], home: Optional[str] = None, platform: str = "linux") -> str:
+    """Resolve the spellings a manifest uses for "the user's home".
+
+    The manifest is written in ``~`` and ``%USERPROFILE%`` because that is what
+    a reader should see; the machine records absolute paths. Without this the
+    two never compare equal, and every artifact entry scores as a miss for a
+    reason that has nothing to do with the collector.
+    """
+    if not path:
+        return ""
+    text = str(path)
+    if home:
+        text = text.replace("~", home).replace("%USERPROFILE%", home)
+        text = text.replace("%APPDATA%", posixpath.join(home, "AppData/Roaming"))
+    return norm_path(text, platform)
+
+
+def norm_path(path: Optional[str], platform: str = "linux") -> str:
+    """One spelling for a path, so two spellings of one file compare equal.
+
+    Windows is case-insensitive and mixes separators, and usr-merge means a
+    Linux binary has two true names. Neither is a difference the scorer should
+    be able to see.
+    """
+    if not path:
+        return ""
+    text = str(path).replace("\\", "/").rstrip("/")
+    if platform == "win":
+        text = text.lower()
+    return text
+
+
+def norm_command(command: Optional[str]) -> str:
+    """A launcher's identity is its name, not where it was found.
+
+    ``C:\\Tools\\npx.exe``, ``/usr/local/bin/npx`` and ``npx`` are one launcher;
+    treating them as three would split a duplicate into two clean matches and
+    hide exactly the defect these entries exist to provoke.
+    """
+    if not command:
+        return ""
+    base = posixpath.basename(str(command).replace("\\", "/")).lower()
+    return base[:-4] if base.endswith(".exe") else base
+
+
+def launch_key(command: Optional[str], args: Optional[Sequence[str]],
+               url: Optional[str] = None) -> Tuple[str, Tuple[str, ...], str]:
+    """What a declaration launches, reduced to something comparable.
+
+    Redacted tokens become a wildcard rather than a value: the manifest holds
+    the plaintext a config was written with, the snapshot holds the collector's
+    redaction of it, and requiring those to be equal would mean every entry that
+    carries a credential scored as a miss - punishing the collector for doing
+    the right thing.
+    """
+    normalized = []
+    for arg in args or []:
+        text = str(arg)
+        normalized.append("*" if REDACTED in text or "{{canary:" in text else text)
+    return norm_command(command), tuple(normalized), (url or "").rstrip("/")
+
+
+def _asset_launch_key(asset: Asset) -> Tuple[str, Tuple[str, ...], str]:
+    risk = asset.risk or {}
+    return launch_key(risk.get("command"), risk.get("args"), (asset.network or {}).get("endpoint"))
+
+
+def _asset_paths(asset: Asset, platform: str) -> List[str]:
+    """Every path that could reasonably identify this asset.
+
+    Evidence paths are included because an artifact is discovered *at* a path
+    that is not always the path the resolver settles on as ``install_path`` -
+    a hook lives in a settings file, not in a file of its own.
+    """
+    paths = [asset.install_path, asset.install_root]
+    paths.extend(item.path for item in asset.evidence)
+    return [norm_path(path, platform) for path in paths if path]
+
+
+# -- matching ----------------------------------------------------------
+
+
+class Match:
+    """One entry's verdict, with the assets that produced it.
+
+    Carries the assets rather than just a count because the aggregate number is
+    for tracking and the individual rows are what somebody fixes.
+    """
+
+    __slots__ = ("entry", "assets", "outcome", "detail")
+
+    def __init__(self, entry: Entry, assets: List[Asset], outcome: str, detail: str = ""):
+        self.entry = entry
+        self.assets = assets
+        self.outcome = outcome
+        self.detail = detail
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"id": self.entry.id, "name": self.entry.name, "category": self.entry.category,
+                "outcome": self.outcome, "detail": self.detail,
+                "assets": [{"asset_id": asset.asset_id, "name": asset.name, "kind": asset.kind,
+                            "install_path": asset.install_path, "version": asset.version,
+                            "evidence": [item.to_dict() for item in asset.evidence]}
+                           for asset in self.assets]}
+
+
+def match_all(manifest: Manifest, actual: Dict[str, Any],
+              assets: Iterable[Asset]) -> Tuple[List[Match], List[Asset]]:
+    """Match every scoreable entry, and return whatever no entry claimed.
+
+    Only entries recorded ``installed`` are matched. An entry that a vendor no
+    longer ships, or that failed to install, is not in the denominator at all -
+    scoring it as a miss would blame the collector for the harness's own
+    weather.
+    """
+    platform = actual.get("os", "linux")
+    home = actual.get("home")
+    assets = list(assets)
+    outcomes: List[Match] = []
+    claimed: set = set()
+    statuses = {record.get("id"): record.get("status") for record in _records(actual)}
+
+    for entry in manifest.for_platform(platform):
+        record = (actual.get("entries") or {}).get(entry.id) if isinstance(actual.get("entries"), dict) \
+            else _record_for(actual, entry.id)
+        if entry.is_negative:
+            found = _match_negative(entry, assets, platform, home)
+            outcomes.append(Match(entry, found, "negative"))
+            claimed.update(id(asset) for asset in found)
+            continue
+        if not record or record.get("status") != "installed":
+            outcomes.append(Match(entry, [], "excluded",
+                                  (record or {}).get("status", "not-attempted")))
+            continue
+        if entry.variant_of and statuses.get(entry.variant_of) != "installed":
+            # A second install of a tool that was never installed once proves
+            # nothing about duplication, and scoring it as a miss would blame
+            # the collector for the base entry's absence.
+            outcomes.append(Match(entry, [], "excluded",
+                                  "base %s is %s" % (entry.variant_of,
+                                                     statuses.get(entry.variant_of, "absent"))))
+            continue
+        found = _match_entry(entry, manifest, record, assets, platform, home)
+        claimed.update(id(asset) for asset in found)
+        outcomes.append(Match(entry, found, "matched" if found else "unmatched"))
+
+    unclaimed = [asset for asset in assets if id(asset) not in claimed]
+    return outcomes, unclaimed
+
+
+def _records(actual: Dict[str, Any]) -> List[Dict[str, Any]]:
+    entries = actual.get("entries", [])
+    return list(entries.values()) if isinstance(entries, dict) else list(entries)
+
+
+def _record_for(actual: Dict[str, Any], entry_id: str) -> Optional[Dict[str, Any]]:
+    for record in actual.get("entries", []):
+        if record.get("id") == entry_id:
+            return record
+    return None
+
+
+def _match_entry(entry: Entry, manifest: Manifest, record: Dict[str, Any],
+                 assets: List[Asset], platform: str, home: Optional[str] = None) -> List[Asset]:
+    shape = entry.shape
+    if shape == "install":
+        return _match_install(entry, manifest, record, assets, platform)
+    if shape == "declare":
+        return _match_declare(entry, record, assets, platform, home)
+    if shape == "create":
+        return _match_create(entry, record, assets, platform, home)
+    return _match_state(entry, manifest, record, assets, platform, home)
+
+
+def _match_install(entry: Entry, manifest: Manifest, record: Dict[str, Any],
+                   assets: List[Asset], platform: str) -> List[Asset]:
+    """Catalog id where there is one, the real installed path where there is not.
+
+    A channel variant matches through its *base* entry's catalog id on purpose:
+    the whole point of those rows is that a second install must not become a
+    second asset, so both rows are matched by the same key and judged by how
+    many assets come back. A variant that matched nothing would score as a miss
+    and hide the duplicate it exists to provoke.
+    """
+    catalog_id = entry.catalog_id
+    if not catalog_id and entry.variant_of:
+        catalog_id = manifest.by_id(entry.variant_of).catalog_id
+    if catalog_id:
+        return [asset for asset in assets if asset.catalog_id == catalog_id]
+    target = expand(record.get("path"), None, platform)
+    if target:
+        return [asset for asset in assets if target in _asset_paths(asset, platform)]
+    # A service nothing declared - M-SP-01 - is identified by where it listens.
+    port = entry.install.get("port")
+    if port:
+        return [asset for asset in assets if (asset.network or {}).get("port") == port]
+    return []
+
+
+def _match_declare(entry: Entry, record: Dict[str, Any], assets: List[Asset],
+                   platform: str, home: Optional[str] = None) -> List[Asset]:
+    """A declared server is what it launches - and, where it must be, where it
+    was declared.
+
+    Launch identity alone is not enough for the M-SITE rows: they deliberately
+    declare the *same* trivial server in fourteen different config files so that
+    a missed site shows as a specific miss rather than as a lower total. Keying
+    on the launch line alone would make all fourteen match all fourteen assets
+    and report a duplicate on every one of them. So where the entry names the
+    file it wrote, the file is part of the key.
+
+    Name is the last fallback, and mostly for remote servers: there is no
+    command to compare, and the endpoint may have been redacted along with the
+    credential that reaches it.
+    """
+    declared = entry.declare
+    key = launch_key(declared.get("command"), declared.get("args"), declared.get("url"))
+    by_launch = [asset for asset in assets
+                 if asset.kind == "mcp_server" and _asset_launch_key(asset) == key]
+    site = expand(record.get("path") or entry.path_for(platform), home, platform)
+    if site and len(by_launch) > 1:
+        # Empty is the right answer here, not a fallback. Fourteen sites declare
+        # one server; if this site's file produced no asset while others did,
+        # that site was missed - and returning the other thirteen would report a
+        # duplicate on every row instead of a miss on this one.
+        return [asset for asset in by_launch if site in _asset_paths(asset, platform)]
+    if by_launch:
+        return by_launch
+    name = declared.get("server_name")
+    return [asset for asset in assets if asset.kind == "mcp_server" and asset.name == name]
+
+
+def _match_create(entry: Entry, record: Dict[str, Any],
+                  assets: List[Asset], platform: str, home: Optional[str] = None) -> List[Asset]:
+    """An artifact is the file it is. Matched on the path actually written.
+
+    ``record`` wins over the manifest because the runner expands ``~`` and the
+    per-OS variants, and the expansion is what ended up on disk.
+    """
+    target = expand(record.get("path") or entry.path_for(platform), home, platform)
+    if not target:
+        return []
+    found = [asset for asset in assets if target in _asset_paths(asset, platform)]
+    if found or not entry.expect.get("env_name"):
+        return found
+    # A shell-exported key has no file of its own worth reporting: the signal is
+    # the variable name, wherever the collector chose to hang it.
+    name = entry.expect["env_name"]
+    return [asset for asset in assets if name in (asset.risk or {}).get("env_names", [])]
+
+
+def _match_state(entry: Entry, manifest: Manifest, record: Dict[str, Any],
+                 assets: List[Asset], platform: str, home: Optional[str] = None) -> List[Asset]:
+    """A state attaches to an asset; which asset depends on the method.
+
+    A scheduler entry creates an asset of its own. A runtime or identity entry
+    does not - it changes a field on an asset some other entry installed - so it
+    resolves through ``depends_on`` and is then judged on that field. Sharing an
+    asset between two entries is deliberate and is not a duplicate: duplication
+    is one *entry* matching two assets, never two entries agreeing on one.
+    """
+    state = entry.state
+    if state.get("method") == "scheduler":
+        return _match_scheduler(entry, assets, platform, home)
+    if state.get("method") == "runtime-state" and state.get("parent"):
+        parent = manifest.by_id(state["parent"])
+        base = manifest.by_id(parent.depends_on[0]) if parent.depends_on else None
+        wanted = base.catalog_id if base else None
+        return [asset for asset in assets if asset.parent_agent and
+                (wanted is None or asset.parent_agent == wanted or asset.parent_agent == (base.name if base else ""))]
+    base_id = entry.depends_on[0] if entry.depends_on else None
+    if not base_id:
+        return []
+    base = manifest.by_id(base_id)
+    if base.catalog_id:
+        return [asset for asset in assets if asset.catalog_id == base.catalog_id]
+    return []
+
+
+def _match_scheduler(entry: Entry, assets: List[Asset], platform: str,
+                     home: Optional[str] = None) -> List[Asset]:
+    """A scheduled agent, discriminated by its backend rather than its command.
+
+    Two schedulers on one OS - cron and a systemd user unit - run the identical
+    command on purpose, because the question is whether the collector reads both
+    surfaces. Matching on the command alone makes each entry match both assets
+    and reports two duplicates where there are none, so the backend is what
+    separates them: the unit file where there is one, the probe that found it
+    where there is not.
+    """
+    state = entry.state
+    backend = str(state.get("backend") or "").lower()
+    unit = expand(state.get("path"), home, platform)
+    scheduled = [asset for asset in assets if asset.kind == "scheduled_agent"]
+
+    if unit:
+        at_path = [asset for asset in scheduled if unit in _asset_paths(asset, platform)]
+        if at_path:
+            return at_path
+    by_backend = [asset for asset in scheduled
+                  if any(backend in (item.matched_on or "").lower() for item in asset.evidence)]
+    if by_backend:
+        return by_backend
+    if state.get("task_name"):
+        return [asset for asset in scheduled if asset.name == state["task_name"]]
+    command = norm_command((state.get("command") or "").split(" ")[0])
+    return [asset for asset in scheduled
+            if norm_command((asset.risk or {}).get("command")) == command]
+
+
+def _match_negative(entry: Entry, assets: List[Asset], platform: str,
+                    home: Optional[str] = None) -> List[Asset]:
+    """Assets attributable to a negative control.
+
+    Attribution is the whole value: an FP that names the control that provoked
+    it is a bug report, and an FP that names nothing is a mystery.
+    """
+    detect = entry.detect or {}
+    names = {str(name).lower() for name in detect.get("names", [])}
+    paths = {expand(path, home, platform) for path in detect.get("paths", [])}
+    ports = set(detect.get("ports", []))
+    found = []
+    for asset in assets:
+        at_path = bool(paths & set(_asset_paths(asset, platform)))
+        # Where a control knows where it lives, the path decides. Name alone
+        # attributes by coincidence: an MCP server legitimately called `git` is
+        # not the `git` binary N-04 installed, and blaming the control for it
+        # would turn a correct report into a fabricated false positive.
+        named = (asset.name or "").lower() in names and (not paths or at_path)
+        if at_path or named or (ports and (asset.network or {}).get("port") in ports):
+            found.append(asset)
+    return found

--- a/Discovery/tests/test_match.py
+++ b/Discovery/tests/test_match.py
@@ -1,0 +1,186 @@
+"""Matching: the join between what was installed and what was reported.
+
+Every rule here has a failure mode in both directions - a missed join reads as
+a miss the collector never made, and a loose join hides a real one - so each
+gets a test that would fail if the rule were relaxed.
+"""
+
+import unittest
+
+from . import manifest as manifest_module
+from .scoring import match
+from .scoring.snapshot import Asset
+
+
+def _asset(**payload):
+    base = {"asset_id": payload.get("name", "x"), "kind": "cli_agent", "name": "tool",
+            "evidence": [], "risk": {"factors": []}, "network": {}}
+    base.update(payload)
+    return Asset(base)
+
+
+def _actual(platform="linux", home="/home/tester", entries=None):
+    return {"os": platform, "home": home, "entries": entries or []}
+
+
+class Normalization(unittest.TestCase):
+    def test_a_launcher_is_its_name_not_its_location(self):
+        self.assertEqual(match.norm_command("C:\\Tools\\NPX.EXE"), "npx")
+        self.assertEqual(match.norm_command("/usr/local/bin/npx"), "npx")
+
+    def test_windows_paths_compare_case_insensitively(self):
+        self.assertEqual(match.norm_path("C:\\Program Files\\Code\\Code.exe", "win"),
+                         match.norm_path("c:/program files/code/code.exe", "win"))
+
+    def test_linux_paths_do_not(self):
+        self.assertNotEqual(match.norm_path("/usr/bin/Claude", "linux"),
+                            match.norm_path("/usr/bin/claude", "linux"))
+
+    def test_home_is_expanded_from_the_run(self):
+        self.assertEqual(match.expand("~/bin/x", "/home/tester"), "/home/tester/bin/x")
+        self.assertEqual(match.expand("%USERPROFILE%/bin/x", "C:/Users/t", "win"),
+                         "c:/users/t/bin/x")
+
+    def test_a_redacted_argument_is_a_wildcard(self):
+        """The manifest holds the plaintext a config was written with and the
+        snapshot holds the redaction of it. Requiring equality would score every
+        credential-carrying entry as a miss - punishing the collector for doing
+        the right thing."""
+        declared = match.launch_key("node", ["server.js", "--token", "{{canary:t}}"])
+        reported = match.launch_key("node", ["server.js", "--token", "[REDACTED]"])
+        self.assertEqual(declared, reported)
+
+
+class Joining(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+
+    def _match(self, entry_id, assets, record=None, platform="linux"):
+        entry = self.manifest.by_id(entry_id)
+        record = record or {"id": entry_id, "status": "installed"}
+        actual = _actual(platform=platform, entries=[record])
+        outcomes, unclaimed = match.match_all(self.manifest, actual, assets)
+        found = next(item for item in outcomes if item.entry.id == entry_id)
+        return found, unclaimed
+
+    def test_an_installed_tool_joins_on_catalog_id(self):
+        found, _ = self._match("T-CLI-01", [_asset(catalog_id="claude-code", name="Claude Code")])
+        self.assertEqual(found.outcome, "matched")
+
+    def test_a_variant_joins_through_its_base(self):
+        """T-CHAN-04 has no catalog id of its own. If it matched nothing it
+        would score as a miss and hide the duplicate it exists to provoke."""
+        assets = [_asset(catalog_id="claude-code", name="Claude Code")]
+        records = [{"id": "T-CLI-01", "status": "installed"},
+                   {"id": "T-CHAN-04", "status": "installed"}]
+        outcomes, _ = match.match_all(self.manifest, _actual(entries=records), assets)
+        variant = next(item for item in outcomes if item.entry.id == "T-CHAN-04")
+        self.assertEqual(len(variant.assets), 1)
+
+    def test_a_variant_of_an_uninstalled_base_is_excluded(self):
+        """A second install of a tool that was never installed once proves
+        nothing, and scoring it as a miss would blame the collector."""
+        records = [{"id": "T-APP-02", "status": "unimplemented"},
+                   {"id": "T-CHAN-07", "status": "installed"}]
+        outcomes, _ = match.match_all(self.manifest, _actual(entries=records), [])
+        variant = next(item for item in outcomes if item.entry.id == "T-CHAN-07")
+        self.assertEqual(variant.outcome, "excluded")
+        self.assertIn("T-APP-02", variant.detail)
+
+    def test_identical_declarations_are_separated_by_their_site(self):
+        """Fourteen sites declare one server. Keying on the launch line alone
+        would make all fourteen match all fourteen and report a duplicate on
+        every row."""
+        shared = {"kind": "mcp_server", "risk": {"factors": [], "command": "node",
+                                                 "args": ["~/dev/tools/adr-probe-server.js"]}}
+        at_cc = _asset(asset_id="1", name="adr-probe-cc",
+                       install_path="/home/tester/.claude.json", **shared)
+        at_cursor = _asset(asset_id="2", name="adr-probe-cursor",
+                           install_path="/home/tester/.cursor/mcp.json", **shared)
+        records = [{"id": "M-SITE-01", "status": "installed", "path": "/home/tester/.claude.json"},
+                   {"id": "M-SITE-03", "status": "installed",
+                    "path": "/home/tester/.cursor/mcp.json"}]
+        outcomes, _ = match.match_all(self.manifest, _actual(entries=records), [at_cc, at_cursor])
+        by_id = {item.entry.id: item for item in outcomes}
+        self.assertEqual([a.name for a in by_id["M-SITE-01"].assets], ["adr-probe-cc"])
+        self.assertEqual([a.name for a in by_id["M-SITE-03"].assets], ["adr-probe-cursor"])
+
+    def test_a_site_that_produced_nothing_is_a_miss_not_a_match(self):
+        shared = {"kind": "mcp_server", "risk": {"factors": [], "command": "node",
+                                                 "args": ["~/dev/tools/adr-probe-server.js"]}}
+        records = [{"id": "M-SITE-01", "status": "installed", "path": "/home/tester/.claude.json"},
+                   {"id": "M-SITE-03", "status": "installed",
+                    "path": "/home/tester/.cursor/mcp.json"}]
+        assets = [_asset(asset_id="1", name="adr-probe-cc",
+                         install_path="/home/tester/.claude.json", **shared),
+                  _asset(asset_id="2", name="other", install_path="/home/tester/.zed/settings.json",
+                         **shared)]
+        outcomes, _ = match.match_all(self.manifest, _actual(entries=records), assets)
+        cursor = next(item for item in outcomes if item.entry.id == "M-SITE-03")
+        self.assertEqual(cursor.assets, [])
+
+    def test_an_artifact_joins_on_the_path_that_was_written(self):
+        asset = _asset(kind="skill", name="SKILL.md",
+                       install_path="/home/tester/.claude/skills/pdf-filler/SKILL.md")
+        found, _ = self._match("S-01", [asset], record={
+            "id": "S-01", "status": "installed",
+            "path": "/home/tester/.claude/skills/pdf-filler/SKILL.md"})
+        self.assertEqual(found.outcome, "matched")
+
+    def test_a_hook_joins_through_evidence_rather_than_install_path(self):
+        """A hook lives inside a settings file, not in a file of its own."""
+        asset = _asset(kind="hook", name="PreToolUse:*", install_path=None,
+                       evidence=[{"probe": "agent_artifact", "channel": "config",
+                                  "path": "/home/tester/.claude/settings.json",
+                                  "matched_on": "hook:user"}])
+        found, _ = self._match("S-13", [asset], record={
+            "id": "S-13", "status": "installed", "path": "/home/tester/.claude/settings.json"})
+        self.assertEqual(found.outcome, "matched")
+
+    def test_two_schedulers_running_one_command_are_not_duplicates(self):
+        """cron and a systemd unit run the identical command on purpose. Keying
+        on the command alone reports two duplicates where there are none."""
+        cron = _asset(asset_id="c", kind="scheduled_agent", name="cron:claude",
+                      risk={"factors": [], "command": "claude"},
+                      evidence=[{"probe": "scheduler", "channel": "config", "path": "",
+                                 "matched_on": "scheduler:cron"}])
+        unit = _asset(asset_id="s", kind="scheduled_agent", name="adr-agent.service",
+                      install_path="/home/tester/.config/systemd/user/adr-agent.service",
+                      risk={"factors": [], "command": "claude"},
+                      evidence=[{"probe": "scheduler", "channel": "config",
+                                 "path": "/home/tester/.config/systemd/user/adr-agent.service",
+                                 "matched_on": "scheduler:systemd"}])
+        records = [{"id": "AG-05", "status": "installed"}, {"id": "AG-06", "status": "installed"},
+                   {"id": "T-CLI-01", "status": "installed"}]
+        outcomes, _ = match.match_all(self.manifest, _actual(entries=records), [cron, unit])
+        by_id = {item.entry.id: item for item in outcomes}
+        self.assertEqual([a.asset_id for a in by_id["AG-05"].assets], ["c"])
+        self.assertEqual([a.asset_id for a in by_id["AG-06"].assets], ["s"])
+
+    def test_a_negative_control_does_not_claim_an_asset_by_name_alone(self):
+        """An MCP server legitimately called `git` is not the `git` binary N-04
+        installed. Attributing it would turn a correct report into a fabricated
+        false positive."""
+        server = _asset(kind="mcp_server", name="git", install_path="/home/tester/.claude.json")
+        outcomes, unclaimed = match.match_all(
+            self.manifest, _actual(entries=[{"id": "N-04", "status": "installed"}]), [server])
+        control = next(item for item in outcomes if item.entry.id == "N-04")
+        self.assertEqual(control.assets, [])
+        self.assertEqual(len(unclaimed), 1)
+
+    def test_a_negative_control_claims_an_asset_at_its_own_path(self):
+        asset = _asset(kind="mcp_server", name="mcp-backup.sh",
+                       install_path="/home/tester/bin/mcp-backup.sh")
+        found, _ = self._match("N-07", [asset])
+        self.assertEqual(len(found.assets), 1)
+
+    def test_an_entry_that_never_installed_is_excluded_from_scoring(self):
+        found, _ = self._match("T-RT-06", [], record={"id": "T-RT-06", "status": "failed",
+                                                      "reason": "CUDA absent"})
+        self.assertEqual(found.outcome, "excluded")
+        self.assertEqual(found.detail, "failed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #61.

The join between what was installed and what was reported. Matching is by entry **shape**, not by category:

| shape | joined on |
|---|---|
| `install` | catalog id, else the real installed path |
| `declare` | what it launches — and where it was declared |
| `create` | the path actually written |
| `state` | the asset the state attaches to |

Getting this wrong is expensive in both directions: a missed join reads as a miss the collector never made, and a loose join hides a real one. So every rule is narrow, every fallback is explicit, and each has a test that fails if it is relaxed.

## Four rules that earn their complexity

**A channel variant joins through its base entry's catalog id.** `T-CHAN-04` has none of its own. If it matched nothing it would score as a miss and hide the duplicate it exists to provoke.

**The site is part of the key for declarations.** The fourteen `M-SITE` rows declare the *same* trivial server on purpose, so that a missed site shows as a specific miss rather than a lower total. Keying on the launch line alone would make all fourteen match all fourteen and report a duplicate on every one. Corollary: a site that names a file and finds nothing there is a **miss**, not a fallback to the other thirteen.

**Two schedulers running one command are separated by their backend.** `AG-05` (cron) and `AG-06` (systemd) run the identical command deliberately — the question is whether the collector reads both surfaces. Matching on the command reports two duplicates where there are none.

**A negative control claims by name only when it declares no path.** An MCP server legitimately called `git` is not the `git` binary `N-04` installed. Attributing it would turn a correct report into a fabricated false positive.

## Redacted arguments are wildcards

The manifest holds the plaintext a config was written with; the snapshot holds the collector's redaction of it. Requiring those to be equal would score every credential-carrying entry as a miss — punishing the collector for doing the right thing.

## Verification

```
$ python3 -m unittest discover -s tests -t . -q
Ran 34 tests in 0.014s
OK
```