### PR TITLE
test(discovery): compute TP/FP/FN/DUP and field accuracy

### DIFF
--- a/Discovery/tests/scoring/__init__.py
+++ b/Discovery/tests/scoring/__init__.py
@@ -6,6 +6,9 @@ about by somebody who has never provisioned a guest.
 """
 
 from .match import load_snapshot, match_all
+from .schema import SCORE_VERSION
+from .score import score, score_run
 from .snapshot import Asset, Snapshot, added_assets, duplicate_ids
 
-__all__ = ["Asset", "Snapshot", "added_assets", "duplicate_ids", "load_snapshot", "match_all"]
+__all__ = ["Asset", "Snapshot", "added_assets", "duplicate_ids", "load_snapshot", "match_all",
+           "score", "score_run", "SCORE_VERSION"]

--- a/Discovery/tests/scoring/schema.py
+++ b/Discovery/tests/scoring/schema.py
@@ -1,0 +1,60 @@
+"""The shape of ``score.json``.
+
+Every miss and every invention is keyed by manifest id, so a regression reads
+as ``M-SITE-08 went from TP to FN`` rather than as "MCP recall dropped". The
+aggregate is for trends; the ids are what somebody fixes.
+"""
+
+from typing import Any, Dict, List
+
+#: Bumped when a consumer of score.json would have to change. Trend tracking
+#: compares runs across months, and a silently reshaped file makes the history
+#: wrong rather than absent.
+SCORE_VERSION = 1
+
+OUTCOMES = ("tp", "fp", "fn", "dup")
+
+#: Fields compared over true positives only. Reported per field rather than
+#: blended: a collector that always gets `version` right and always gets
+#: `config_scope` wrong has a specific bug, and an average hides it.
+SCORED_FIELDS = ("version", "install_path", "install_method", "config_scope",
+                 "transport", "pinned", "liveness")
+
+def empty_totals() -> Dict[str, Any]:
+    return {"tp": 0, "fp": 0, "fn": 0, "dup": 0, "recall": None, "precision": None}
+
+
+def ratios(totals: Dict[str, Any]) -> Dict[str, Any]:
+    """Recall and precision, or ``None`` where the denominator is empty.
+
+    ``None`` rather than 1.0: a category with nothing installed has no recall,
+    and recording a perfect score for it would flatter every pooled average
+    somebody later computes from this file.
+    """
+    tp, fp, fn = totals["tp"], totals["fp"], totals["fn"]
+    totals["recall"] = round(tp / (tp + fn), 4) if (tp + fn) else None
+    totals["precision"] = round(tp / (tp + fp), 4) if (tp + fp) else None
+    return totals
+
+
+def blank_score(run: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "score_version": SCORE_VERSION,
+        "run": run,
+        "baseline": {},
+        "manifest": {},
+        "totals": empty_totals(),
+        "by_category": {},
+        "fields": {},
+        "errors": {},
+        "review_queue": {},
+        "misses": [],
+        "inventions": [],
+        "duplicates": [],
+        "excluded": [],
+    }
+
+
+def sort_findings(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Stable order by manifest id, so two runs diff cleanly."""
+    return sorted(rows, key=lambda row: str(row.get("id") or row.get("name") or ""))

--- a/Discovery/tests/scoring/score.py
+++ b/Discovery/tests/scoring/score.py
@@ -1,0 +1,303 @@
+"""The scorer: three JSON files in, one verdict out.
+
+``score()`` is pure - no VM, no network, no clock - which is what makes it
+testable in milliseconds against runs recorded months apart, and what lets a
+scoring fix be replayed over every historical run to show exactly which
+verdicts moved.
+"""
+
+import json
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..manifest import Entry, Manifest
+from . import schema
+from .match import Match, expand, load_snapshot, match_all, norm_path
+from .snapshot import Asset, Snapshot, added_assets, duplicate_ids
+
+
+def score_run(run_dir: str, manifest: Manifest) -> Dict[str, Any]:
+    """Score a run directory: the two snapshots plus what actually installed.
+
+    A run directory is the unit of replay. Everything the scorer needs is in it,
+    which is why a failed run can be re-scored without being re-run.
+    """
+    before = load_snapshot(os.path.join(run_dir, "before.json"))
+    after = load_snapshot(os.path.join(run_dir, "after.json"))
+    with open(os.path.join(run_dir, "manifest.actual.json"), encoding="utf-8") as handle:
+        actual = json.load(handle)
+    return score(before, after, actual, manifest)
+
+
+def score(before: Snapshot, after: Snapshot, actual: Dict[str, Any],
+          manifest: Manifest) -> Dict[str, Any]:
+    """Compare what the collector reported against what was actually installed."""
+    platform = actual.get("os", "linux")
+    for name, snapshot in (("before", before), ("after", after)):
+        repeated = duplicate_ids(snapshot)
+        if repeated:
+            # A repeated id would silently halve the delta. Refusing is the only
+            # honest response: any score computed from it would be wrong in a
+            # direction that flatters the collector.
+            raise ValueError("%s snapshot repeats asset_id %s" % (name, repeated))
+    arrived = added_assets(before, after)
+    matches, unclaimed = match_all(manifest, actual, arrived)
+
+    result = schema.blank_score({
+        "id": actual.get("run_id", ""),
+        "os": platform,
+        "image": actual.get("image", ""),
+        "collector": actual.get("collector", ""),
+        "catalog_version": after.stats.get("catalog_version"),
+        "scan_ms": after.stats.get("wall_ms"),
+    })
+    result["baseline"] = _baseline(before)
+    result["manifest"] = _denominator(actual, manifest, platform)
+
+    totals, by_category, misses, duplicates, excluded = _tally(matches, platform)
+    inventions = _inventions(matches, unclaimed, totals, by_category)
+
+    result["totals"] = schema.ratios(totals)
+    result["by_category"] = {name: schema.ratios(values) for name, values in sorted(by_category.items())}
+    result["misses"] = schema.sort_findings(misses)
+    result["inventions"] = schema.sort_findings(inventions)
+    result["duplicates"] = schema.sort_findings(duplicates)
+    result["excluded"] = schema.sort_findings(excluded)
+    result["fields"] = _field_accuracy(matches, actual, platform)
+    result["errors"] = _errors(after, manifest, platform, actual.get("home"))
+    result["review_queue"] = _review_queue(after, manifest, platform, actual.get("home"))
+    return result
+
+
+# -- the parts ---------------------------------------------------------
+
+
+def _baseline(before: Snapshot) -> Dict[str, Any]:
+    """The noise floor. Anything here is a false positive with nothing to blame.
+
+    Not a formality: a baseline that is not near-empty invalidates the whole
+    run, because a reported asset can no longer be attributed to the manifest.
+    """
+    return {"asset_count": len(before.assets), "clean": not before.assets,
+            "review_queue_count": len(before.review_queue),
+            "assets": [{"name": asset.name, "kind": asset.kind, "install_path": asset.install_path}
+                       for asset in before.assets]}
+
+
+def _denominator(actual: Dict[str, Any], manifest: Manifest, platform: str) -> Dict[str, Any]:
+    """How many entries were in play, and why the rest were not.
+
+    A silently shrinking denominator flatters every recall number computed from
+    it, so ``failed`` and ``unimplemented`` are counted separately from
+    ``unavailable`` and surfaced in their own right.
+    """
+    statuses: Dict[str, int] = {}
+    for record in _records(actual):
+        statuses[record.get("status", "unknown")] = statuses.get(record.get("status", "unknown"), 0) + 1
+    return {"applicable": len(manifest.for_platform(platform)),
+            "installed": statuses.get("installed", 0),
+            "unavailable": statuses.get("unavailable", 0),
+            "failed": statuses.get("failed", 0),
+            "unimplemented": statuses.get("unimplemented", 0),
+            "by_status": statuses}
+
+
+def _records(actual: Dict[str, Any]) -> List[Dict[str, Any]]:
+    entries = actual.get("entries", [])
+    return list(entries.values()) if isinstance(entries, dict) else list(entries)
+
+
+def _tally(matches: List[Match], platform: str) -> Tuple[Dict[str, Any], Dict[str, Any],
+                                                         List[Dict[str, Any]], List[Dict[str, Any]],
+                                                         List[Dict[str, Any]]]:
+    """TP, FN and DUP per entry, and per category.
+
+    A duplicate is not a partial success and is never also counted as a TP: it
+    inflates a fleet inventory, and folding it into the good column is what let
+    it recur.
+    """
+    totals = schema.empty_totals()
+    by_category: Dict[str, Dict[str, Any]] = {}
+    misses, duplicates, excluded = [], [], []
+
+    for match in matches:
+        entry = match.entry
+        bucket = by_category.setdefault(entry.category, schema.empty_totals())
+        if match.outcome == "excluded":
+            excluded.append({"id": entry.id, "name": entry.name, "category": entry.category,
+                             "reason": match.detail})
+            continue
+        if entry.is_negative:
+            continue  # counted as inventions, where their assets belong
+        if len(match.assets) == 1:
+            totals["tp"] += 1
+            bucket["tp"] += 1
+        elif not match.assets:
+            totals["fn"] += 1
+            bucket["fn"] += 1
+            misses.append({"id": entry.id, "name": entry.name, "category": entry.category,
+                           "shape": entry.shape, "expected": _expected_of(entry, platform)})
+        else:
+            totals["dup"] += 1
+            bucket["dup"] += 1
+            duplicates.append({"id": entry.id, "name": entry.name, "category": entry.category,
+                               "count": len(match.assets),
+                               "assets": [{"asset_id": asset.asset_id, "name": asset.name,
+                                           "install_path": asset.install_path,
+                                           "install_method": asset.install_method}
+                                          for asset in match.assets]})
+    return totals, by_category, misses, duplicates, excluded
+
+
+def _expected_of(entry: Entry, platform: str) -> Dict[str, Any]:
+    """What the miss should have looked like, for the person diagnosing it."""
+    expected = {"catalog_id": entry.catalog_id, "path": entry.path_for(platform)}
+    if entry.declare:
+        expected["launches"] = " ".join([str(entry.declare.get("command") or entry.declare.get("url") or "")]
+                                        + [str(arg) for arg in entry.declare.get("args", [])])
+    return {key: value for key, value in expected.items() if value}
+
+
+def _inventions(matches: List[Match], unclaimed: List[Asset],
+                totals: Dict[str, Any], by_category: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Assets nothing installed, attributed to a control where one explains them.
+
+    Both kinds cost an operator the same time, so both are FPs. Only the
+    attribution differs, and the attributed ones are the actionable ones: a
+    negative control that fired names the exact lookalike that fooled the
+    collector.
+    """
+    inventions = []
+    for match in matches:
+        if not match.entry.is_negative or not match.assets:
+            continue
+        bucket = by_category.setdefault("negative_control", schema.empty_totals())
+        for asset in match.assets:
+            totals["fp"] += 1
+            bucket["fp"] += 1
+            inventions.append({"id": match.entry.id, "name": asset.name, "kind": asset.kind,
+                               "attributed_to": match.entry.id, "why_wrong": match.entry.reason,
+                               "install_path": asset.install_path,
+                               "evidence": [item.to_dict() for item in asset.evidence]})
+    for asset in unclaimed:
+        totals["fp"] += 1
+        bucket = by_category.setdefault(_category_of(asset), schema.empty_totals())
+        bucket["fp"] += 1
+        inventions.append({"id": None, "name": asset.name, "kind": asset.kind,
+                           "attributed_to": None,
+                           "why_wrong": "reported, but nothing in the manifest installed it",
+                           "install_path": asset.install_path,
+                           "evidence": [item.to_dict() for item in asset.evidence]})
+    return inventions
+
+
+#: Asset kinds mapped onto the report's categories, so an unattributed invention
+#: lands in the table a reader would look for it in.
+_KIND_TO_CATEGORY = {
+    "cli_agent": "cli_agent", "app": "app", "ai_browser": "app", "extension": "extension",
+    "model_runtime": "model_runtime", "ai_frontend": "model_runtime", "agent_platform": "model_runtime",
+    "mcp_server": "mcp_server", "mcp_bundle": "mcp_server",
+    "skill": "artifact", "plugin": "artifact", "hook": "artifact", "instructions": "artifact",
+    "rules": "artifact", "agent": "agent", "scheduled_agent": "agent", "cloud_agent": "agent",
+    "ci_agent": "agent", "model_weights": "model_runtime",
+}
+
+
+def _category_of(asset: Asset) -> str:
+    return _KIND_TO_CATEGORY.get(asset.kind, "artifact")
+
+
+def _field_accuracy(matches: List[Match], actual: Dict[str, Any], platform: str) -> Dict[str, Any]:
+    """Per-field accuracy over true positives only.
+
+    A tool found with the wrong facts is only partly found. Version and path are
+    compared against what the runner *recorded installing*, not against the
+    manifest: the manifest states intent, and intent is not what is on the disk.
+    """
+    records = {record["id"]: record for record in _records(actual)}
+    tallies: Dict[str, Dict[str, Any]] = {}
+
+    for match in matches:
+        if match.entry.is_negative or len(match.assets) != 1:
+            continue
+        asset = match.assets[0]
+        record = records.get(match.entry.id, {})
+        for field, expected in _expectations(match.entry, record, platform).items():
+            observed = _observed(asset, field, platform)
+            tally = tallies.setdefault(field, {"checked": 0, "correct": 0, "wrong": []})
+            tally["checked"] += 1
+            if _equal(field, expected, observed, platform):
+                tally["correct"] += 1
+            else:
+                tally["wrong"].append({"id": match.entry.id, "expected": expected, "observed": observed})
+
+    return {field: dict(tally, accuracy=round(tally["correct"] / tally["checked"], 4))
+            for field, tally in sorted(tallies.items()) if tally["checked"]}
+
+
+def _expectations(entry: Entry, record: Dict[str, Any], platform: str) -> Dict[str, Any]:
+    """What this entry claims about the asset, from the manifest and from reality."""
+    expected: Dict[str, Any] = {}
+    for field in schema.SCORED_FIELDS:
+        if field in entry.expect:
+            expected[field] = entry.expect[field]
+    if record.get("version"):
+        expected["version"] = record["version"]
+    if record.get("path"):
+        expected["install_path"] = record["path"]
+    return expected
+
+
+def _observed(asset: Asset, field: str, platform: str) -> Any:
+    if field == "pinned":
+        return (asset.risk or {}).get("pinned")
+    return getattr(asset, field, None)
+
+
+def _equal(field: str, expected: Any, observed: Any, platform: str) -> bool:
+    if field == "install_path":
+        return norm_path(str(observed), platform) == norm_path(str(expected), platform)
+    if field == "pinned":
+        return bool(expected) == bool(observed)
+    return str(expected) == str(observed)
+
+
+def _errors(after: Snapshot, manifest: Manifest, platform: str,
+            home: Optional[str] = None) -> Dict[str, Any]:
+    """Errors must be zero, or attributable to something the manifest created.
+
+    N-09's dangling symlink is a deliberate error and is expected to produce
+    one. Anything else is the collector tripping over the real world, and a run
+    that shrugs at unexplained errors is a run that stops noticing them.
+    """
+    explained_paths = {expand(path, home, platform)
+                       for entry in manifest.for_platform(platform) if entry.explains_error
+                       for path in ([entry.path_for(platform)] + list((entry.detect or {}).get("paths", [])))
+                       if path}
+    unexplained = []
+    for error in after.errors:
+        if norm_path(error.get("path"), platform) not in explained_paths:
+            unexplained.append(error)
+    return {"count": len(after.errors), "unexplained": len(unexplained), "detail": unexplained}
+
+
+def _review_queue(after: Snapshot, manifest: Manifest, platform: str,
+                  home: Optional[str] = None) -> Dict[str, Any]:
+    """The open-world check, scored as its own pass/fail.
+
+    Being confidently wrong and being silent are different failures. An
+    uncatalogued AI wrapper must appear in ``review_queue`` and must not appear
+    in ``assets``, and neither half implies the other.
+    """
+    wanted = [entry for entry in manifest.for_platform(platform) if entry.must_be_reviewed]
+    queued_paths = {norm_path(item.get("path"), platform) for item in after.review_queue}
+    queued_names = {str(item.get("name", "")).lower() for item in after.review_queue}
+    rows = []
+    for entry in wanted:
+        names = {str(name).lower() for name in (entry.detect or {}).get("names", [])}
+        paths = {expand(path, home, platform) for path in (entry.detect or {}).get("paths", [])}
+        found = bool(names & queued_names) or bool(paths & queued_paths)
+        rows.append({"id": entry.id, "name": entry.name, "queued": found})
+    return {"expected": len(wanted), "queued": sum(1 for row in rows if row["queued"]),
+            "size": len(after.review_queue), "entries": rows,
+            "passed": all(row["queued"] for row in rows)}

--- a/Discovery/tests/test_score.py
+++ b/Discovery/tests/test_score.py
@@ -1,0 +1,109 @@
+"""The scorer, replayed over a recorded run.
+
+The recorded directory is the load-bearing fixture: a run captured once and
+checked in, so a change to the scorer can be replayed against it and show
+exactly which verdicts moved. These assertions are deliberately exact - a
+scorer whose totals drift by one has a bug, and a test that only checked
+"recall is high" would not notice.
+"""
+
+import json
+import os
+import unittest
+
+from . import manifest as manifest_module
+from .scoring import score_run
+
+RECORDED = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "recorded", "synthetic-linux")
+
+
+def _load(name):
+    with open(os.path.join(RECORDED, name + ".json"), encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+class RecordedRun(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+        cls.score = score_run(RECORDED, cls.manifest)
+
+    def test_the_recorded_run_is_labelled_synthetic(self):
+        """A generated run proves the scorer computes what we think it computes.
+        Only a captured one says anything about the collector, so the difference
+        must never be inferable only from a directory name."""
+        self.assertTrue(_load("manifest.actual")["synthetic"])
+
+    def test_totals(self):
+        totals = self.score["totals"]
+        self.assertEqual((totals["tp"], totals["fp"], totals["fn"], totals["dup"]),
+                         (73, 2, 2, 5))
+        self.assertAlmostEqual(totals["recall"], 73 / 75, places=3)
+        self.assertAlmostEqual(totals["precision"], 73 / 75, places=3)
+
+    def test_every_injected_miss_is_reported_by_id(self):
+        """A regression must read as `M-SITE-08 went from TP to FN`, not as
+        `MCP recall dropped`."""
+        self.assertEqual([row["id"] for row in self.score["misses"]], ["M-SITE-08", "T-RT-04"])
+
+    def test_the_duplicate_is_reported_against_every_entry_it_touches(self):
+        """One binary reachable by two names duplicates the base entry, both
+        variants that key on it, and the two states that attach to it."""
+        self.assertEqual([row["id"] for row in self.score["duplicates"]],
+                         ["AG-01", "AG-08", "T-CHAN-01", "T-CHAN-04", "T-CLI-01"])
+        self.assertTrue(all(row["count"] == 2 for row in self.score["duplicates"]))
+
+    def test_an_invention_is_attributed_when_a_control_explains_it(self):
+        inventions = {row["name"]: row for row in self.score["inventions"]}
+        self.assertEqual(inventions["mcp-backup.sh"]["attributed_to"], "N-07")
+        self.assertIn("mcp", inventions["mcp-backup.sh"]["why_wrong"])
+
+    def test_an_invention_nothing_explains_is_still_reported(self):
+        ghost = next(row for row in self.score["inventions"] if row["name"] == "ghost-agent")
+        self.assertIsNone(ghost["attributed_to"])
+        self.assertTrue(ghost["evidence"])
+
+    def test_duplicates_are_not_also_counted_as_true_positives(self):
+        """A duplicate is not a partial success: folding it into the good column
+        is what let it recur."""
+        by_category = self.score["by_category"]
+        self.assertEqual(by_category["cli_agent"]["dup"], 1)      # T-CLI-01
+        self.assertEqual(by_category["channel_variant"]["dup"], 2)  # T-CHAN-01, T-CHAN-04
+        self.assertEqual(by_category["agent"]["dup"], 2)          # AG-01, AG-08
+        # None of the five appear in the good column of their own category.
+        self.assertEqual(sum(values["tp"] for values in by_category.values()),
+                         self.score["totals"]["tp"])
+
+    def test_the_denominator_reports_what_left_it(self):
+        manifest = self.score["manifest"]
+        self.assertEqual(manifest["applicable"], 105)
+        self.assertEqual(manifest["failed"], 1)
+        self.assertGreater(manifest["unimplemented"], 0)
+        self.assertEqual(manifest["installed"] + manifest["failed"] + manifest["unimplemented"]
+                         + manifest["unavailable"], 105)
+
+    def test_field_accuracy_is_per_field(self):
+        fields = self.score["fields"]
+        self.assertIn("version", fields)
+        self.assertIn("config_scope", fields)
+        for name, tally in fields.items():
+            self.assertEqual(tally["checked"], tally["correct"] + len(tally["wrong"]), name)
+
+    def test_the_baseline_is_clean(self):
+        self.assertTrue(self.score["baseline"]["clean"])
+        self.assertEqual(self.score["baseline"]["asset_count"], 0)
+
+    def test_a_deliberate_error_is_explained(self):
+        """N-09's dangling symlink is expected to produce one error. Anything
+        else is the collector tripping over the real world."""
+        self.assertEqual(self.score["errors"]["count"], 1)
+        self.assertEqual(self.score["errors"]["unexplained"], 0)
+
+    def test_the_open_world_entry_reaches_the_review_queue(self):
+        self.assertTrue(self.score["review_queue"]["passed"])
+        self.assertEqual(self.score["review_queue"]["expected"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #62.

The measurement itself, and the shape of `score.json`. The run verdict — canaries and the gate — is the next PR: what the numbers *are* should not change when someone argues about what ought to fail a release.

## Outcomes

| outcome | condition | why separate |
|---|---|---|
| TP | installed, matched exactly once | |
| FP | asset matches no installed entry | an invention; costs an operator real time |
| FN | installed entry matches no asset | a blind spot |
| DUP | installed once, matched by ≥2 assets | **not** a partial success |

`DUP` is tracked apart from `TP` rather than folded into it. A duplicate inflates a fleet inventory, and treating it as mostly-a-success is what let it recur.

## Only installed entries are scored

An entry a vendor no longer ships (`unavailable`), one that failed, or one no recipe implements yet leaves the denominator — but **visibly**. `score.json` reports each count, because a silently shrinking denominator flatters every recall number computed after it.

## Field accuracy is never blended

Per field, over true positives only. A collector that always gets `version` right and always gets `config_scope` wrong has a specific bug; an average hides which. Version and path are compared against **what the runner recorded installing**, not against the manifest — the manifest states intent, and intent is not what is on the disk.

## Empty denominators report `null`, not 1.0

A category with nothing installed has no recall. Recording a perfect score would flatter any average computed downstream.

## Every finding is keyed by manifest id

So a regression reads as `M-SITE-08 went from TP to FN`, not as "MCP recall dropped".

## Verification

Against the recorded run from #61, whose four defects are known:

```
$ python3 -m unittest discover -s tests -t . -q
Ran 48 tests in 0.023s
OK

totals:  tp=73 fp=2 fn=2 dup=5  recall=0.9733 precision=0.9733
misses:  M-SITE-08, T-RT-04                       (the two injected)
dups:    AG-01, AG-08, T-CHAN-01, T-CHAN-04, T-CLI-01   (one binary, two names)
```

The duplicate spanning five entries is correct and worth understanding: one tool reachable by two paths duplicates the base entry, both variants keyed to it, and the two states attached to it.