### PR TITLE
test(discovery): drive Linux and macOS guests

### DIFF
--- a/Discovery/tests/provision/lima.py
+++ b/Discovery/tests/provision/lima.py
@@ -1,0 +1,102 @@
+"""Linux guests on an Apple-silicon host, via lima.
+
+The plan assumes QEMU/KVM, which is right for a Linux build host and wrong for
+the Mac most of this work gets done on: KVM does not exist there, and an x86
+guest would be emulated rather than virtualized. Lima drives Apple's own
+Virtualization framework, so an aarch64 Ubuntu guest runs at native speed.
+
+Same four verbs as every other driver, so nothing above this file knows the
+difference - which is the property the driver interface exists to buy.
+"""
+
+import os
+import subprocess
+from typing import List, Optional, Sequence
+
+from .driver import Driver, Result
+
+
+class LimaDriver(Driver):
+    platform = "linux"
+
+    def __init__(self, instance: str = "adr-disco-linux", template: str = "template://ubuntu-24.04",
+                 cpus: int = 4, memory: int = 6, disk: int = 40, home: Optional[str] = None):
+        self.instance = instance
+        self.template = template
+        self.cpus, self.memory, self.disk = cpus, memory, disk
+        self.image = "lima:%s" % instance
+        self._home = home
+
+    # -- lifecycle -----------------------------------------------------
+
+    def restore(self) -> None:
+        """Back to a clean guest.
+
+        Lima has no snapshot of its own, so "restore" is delete-and-recreate.
+        Slower than a qcow2 overlay, and honest about it: the guarantee the
+        method depends on is that a run starts from a machine with no AI tooling
+        on it, and a fresh instance provides that guarantee unconditionally.
+        """
+        self._lima("stop", "-f", self.instance, allow_failure=True)
+        self._lima("delete", "-f", self.instance, allow_failure=True)
+        self._lima("create", "--name=" + self.instance, "--tty=false",
+                   "--cpus=%d" % self.cpus, "--memory=%d" % self.memory,
+                   "--disk=%d" % self.disk, self.template)
+        self._lima("start", self.instance)
+
+    def ensure_running(self) -> None:
+        """Start an existing instance without discarding it.
+
+        Separate from `restore` on purpose: bootstrapping an image and measuring
+        a collector are different jobs, and only the second one requires the
+        machine to be pristine.
+        """
+        if self.status() != "Running":
+            self._lima("start", self.instance)
+
+    def status(self) -> str:
+        completed = subprocess.run(["limactl", "list", self.instance, "--format", "{{.Status}}"],
+                                   capture_output=True, text=True)
+        return completed.stdout.strip()
+
+    # -- the four verbs ------------------------------------------------
+
+    def run(self, argv: Sequence[str], timeout: int = 600, check: bool = False) -> Result:
+        completed = subprocess.run(
+            ["limactl", "shell", "--workdir", "/", self.instance] + [str(item) for item in argv],
+            capture_output=True, text=True, timeout=timeout)
+        result = Result(argv, completed.returncode, completed.stdout, completed.stderr)
+        if check and not result.ok:
+            raise RuntimeError("guest command failed: %s\n%s" % (" ".join(argv), result.stderr))
+        return result
+
+    def push(self, local: str, remote: str) -> None:
+        self._lima("copy", local, "%s:%s" % (self.instance, remote))
+
+    def pull(self, remote: str, local: str) -> None:
+        self._lima("copy", "%s:%s" % (self.instance, remote), local)
+
+    def write(self, remote: str, content: str, privileged: bool = False) -> None:
+        """Write generated content without a shell in the path.
+
+        `limactl copy` refuses a destination whose directory does not exist, so
+        the directory is created first - which is also what a recipe writing a
+        config site into a fresh guest needs. It also copies as the login user,
+        which is why a privileged destination goes through the staged path in
+        the base class rather than straight to /etc.
+        """
+        if not privileged:
+            self.mkdir(os.path.dirname(remote), check=True)
+        super().write(remote, content, privileged=privileged)
+
+    def home(self) -> str:
+        if self._home is None:
+            self._home = self.run(["sh", "-c", "echo $HOME"]).text() or "/root"
+        return self._home
+
+    # -- plumbing ------------------------------------------------------
+
+    def _lima(self, *args: str, allow_failure: bool = False) -> None:
+        completed = subprocess.run(["limactl"] + list(args), capture_output=True, text=True)
+        if completed.returncode and not allow_failure:
+            raise RuntimeError("limactl %s failed: %s" % (" ".join(args), completed.stderr[-500:]))

--- a/Discovery/tests/provision/tart.py
+++ b/Discovery/tests/provision/tart.py
@@ -1,0 +1,81 @@
+"""macOS guests, via tart on Apple silicon.
+
+macOS guests must run on Apple hardware and Apple's licence limits how many a
+host may run - a hardware and policy question rather than an engineering one,
+and the reason macOS is a later phase than Linux despite having the richest
+manifest.
+
+Restore is ``tart clone`` from a golden VM, which is why the golden VM must
+already carry the authenticated sessions AG-08..AG-11 need: those sign-ins
+cannot be scripted, so they are made by hand once and inherited by every run.
+"""
+
+import json
+import subprocess
+import time
+from typing import Optional
+
+from .driver import SSHDriver
+
+
+class TartDriver(SSHDriver):
+    def __init__(self, golden: str, working: str = "adr-disco-mac-run",
+                 user: str = "admin", identity: Optional[str] = None,
+                 boot_timeout: int = 300, home: Optional[str] = None):
+        super().__init__(host="", user=user, identity=identity, platform="mac", image=golden)
+        self.golden = golden
+        self.working = working
+        self.boot_timeout = boot_timeout
+        self._home = home
+
+    def ensure_running(self) -> str:
+        """Attach to a guest that is already up, without discarding it.
+
+        Separate from `restore` for the same reason as on Linux: building an
+        image and measuring a collector are different jobs, and only the second
+        needs the machine pristine. Bootstrapping a macOS guest costs tens of
+        gigabytes, so throwing one away to check that an installer works would
+        be an expensive way to learn nothing.
+        """
+        if self._state(self.working) != "running":
+            subprocess.Popen(["tart", "run", "--no-graphics", self.working],
+                             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.host = self._wait_for_ip()
+        return self.host
+
+    def _state(self, name: str) -> str:
+        completed = subprocess.run(["tart", "list", "--format", "json"],
+                                   capture_output=True, text=True)
+        if completed.returncode:
+            return ""
+        for row in json.loads(completed.stdout or "[]"):
+            if row.get("Name") == name:
+                return str(row.get("State", "")).lower()
+        return ""
+
+    def home(self) -> str:
+        if self._home is None:
+            self._home = self.run(["sh", "-c", "echo $HOME"]).text() or "/Users/admin"
+        return self._home
+
+    def restore(self) -> None:
+        self._tart("stop", self.working, allow_failure=True)
+        self._tart("delete", self.working, allow_failure=True)
+        self._tart("clone", self.golden, self.working)
+        subprocess.Popen(["tart", "run", "--no-graphics", self.working],
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.host = self._wait_for_ip()
+
+    def _wait_for_ip(self) -> str:
+        deadline = time.time() + self.boot_timeout
+        while time.time() < deadline:
+            completed = subprocess.run(["tart", "ip", self.working], capture_output=True, text=True)
+            if completed.returncode == 0 and completed.stdout.strip():
+                return completed.stdout.strip()
+            time.sleep(3)
+        raise RuntimeError("guest did not report an address within %ds" % self.boot_timeout)
+
+    def _tart(self, *args: str, allow_failure: bool = False) -> None:
+        completed = subprocess.run(["tart"] + list(args), capture_output=True, text=True)
+        if completed.returncode and not allow_failure:
+            raise RuntimeError("tart %s failed: %s" % (" ".join(args), completed.stderr))


### PR DESCRIPTION
Stacked on #67.

Two implementations of the driver contract, both exercised against real VMs.

## Lima for Linux, not QEMU

The plan assumes QEMU/KVM. That is right for a Linux build host and wrong for the Mac most of this work gets done on: KVM does not exist there, and an x86 guest would be *emulated* rather than virtualized. Lima drives Apple's own Virtualization framework, so an aarch64 Ubuntu guest runs at native speed.

Lima has no snapshot of its own, so `restore` is delete-and-recreate. Slower than a qcow2 overlay, and honest about it: what the method depends on is a machine with no AI tooling on it, and a fresh instance provides that unconditionally.

## Tart for macOS

Clones from a golden VM. That golden VM is where `AG-08`..`AG-11` live — OAuth device flows resist unattended scripting, so those sessions are signed in by hand once and inherited by every run.

## `ensure_running` alongside `restore`

Bootstrapping an image and measuring a collector are different jobs, and only the second requires the machine to be pristine. A macOS guest costs tens of gigabytes; discarding one to check that an installer works would be an expensive way to learn nothing.

## What is deliberately absent

**No QEMU driver.** The plan describes one, but it has never been run and the Windows path it exists for is still unvalidated — this host is Apple silicon and cannot run a Windows guest without a hypervisor that is not installed. Merging 70 lines of unexercised code is exactly what a minimum-change series should not do. It belongs in the Windows PR, when there is a Windows guest to prove it against.

## Verification

Both drivers, against live VMs on this host:

```
lima status: Running | home: /home/pengyuzhang.guest
guest: Linux 6.8.0-134-generic aarch64

tart ip: 192.168.64.2 | guest: 15.7.7 arm64
```

The install runs those drivers carried are in the PRs that follow.