### PR TITLE
test(discovery): emit config formats and artifact content

### DIFF
--- a/Discovery/tests/install/__init__.py
+++ b/Discovery/tests/install/__init__.py
@@ -1,0 +1,1 @@
+"""Turning the manifest into a machine, and writing down what happened."""

--- a/Discovery/tests/install/bodies.py
+++ b/Discovery/tests/install/bodies.py
@@ -1,0 +1,122 @@
+"""The content of every file the harness creates.
+
+Kept in one module because these are fixtures, not code: what matters is that a
+skill looks enough like a skill for the collector's parser to accept it, and
+that every one of them is recognizably a test artifact so nobody finds one on a
+machine later and wonders what it is.
+
+Nothing here is realistic beyond what detection requires. A skill with a real
+prompt in it would be a prompt somebody could run.
+"""
+
+import json
+from typing import Any, Dict
+
+MARKER = "ADR end-to-end test artifact - safe to delete"
+
+_FRONT_MATTER = """---
+name: %(name)s
+description: %(description)s
+version: 1.0.0
+---
+
+# %(title)s
+
+%(marker)s
+"""
+
+
+def skill(name: str) -> str:
+    return _FRONT_MATTER % {"name": name, "description": "e2e fixture skill",
+                            "title": name, "marker": MARKER}
+
+
+def command(name: str) -> str:
+    return _FRONT_MATTER % {"name": name, "description": "e2e fixture command",
+                            "title": name, "marker": MARKER}
+
+
+def command_toml(name: str) -> str:
+    return 'description = "e2e fixture command"\nprompt = "%s"\n' % MARKER
+
+
+def subagent(name: str) -> str:
+    return _FRONT_MATTER % {"name": name, "description": "e2e fixture subagent",
+                            "title": name, "marker": MARKER}
+
+
+def output_style(name: str) -> str:
+    return _FRONT_MATTER % {"name": name, "description": "e2e fixture output style",
+                            "title": name, "marker": MARKER}
+
+
+def instructions(name: str) -> str:
+    return "# %s\n\n%s\n" % (name, MARKER)
+
+
+def plugin(name: str) -> Dict[str, str]:
+    """A plugin is a directory, so it returns the files it is made of."""
+    return {"plugin.json": json.dumps({"name": name, "version": "1.0.0",
+                                       "description": MARKER}, indent=2) + "\n",
+            "README.md": "# %s\n\n%s\n" % (name, MARKER)}
+
+
+def hook(event: str, command_line: str) -> Dict[str, Any]:
+    """The fragment merged into a settings file.
+
+    Merged rather than written whole: S-13 and S-16 both land in
+    ``~/.claude/settings.json``, and a recipe that overwrote would silently
+    delete the entry the previous one made and turn it into a miss.
+    """
+    return {"hooks": {event: [{"matcher": "*", "hooks": [
+        {"type": "command", "command": command_line}]}]}}
+
+
+def malformed_bundle() -> str:
+    """A bundle manifest that declares nothing runnable.
+
+    Valid JSON, recognizably a bundle, and with no server in it - so a collector
+    that reports it as a server is inventing one, and a collector that says
+    nothing has silently dropped a malformed file it should have flagged.
+    """
+    return json.dumps({"manifest_version": "0.2", "name": "broken-bundle",
+                       "version": "0.0.1", "description": MARKER,
+                       "server": {}}, indent=2) + "\n"
+
+
+def backup_script() -> str:
+    """N-07: a shell script whose *path* contains "mcp" and whose contents have
+    nothing to do with MCP."""
+    return ("#!/bin/sh\n# %s\n# Copies a directory. Named to look like MCP; it is not.\n"
+            "tar -czf \"$HOME/backup.tgz\" \"$HOME/documents\" 2>/dev/null || true\n" % MARKER)
+
+
+def llm_wrapper() -> str:
+    """N-10: an in-house AI wrapper the catalog has never heard of.
+
+    It must look enough like AI tooling to be worth reviewing - it posts a
+    prompt to a completion endpoint - and must not be classifiable, because the
+    question is whether an unknown tool reaches the review queue instead of
+    being confidently mislabelled or silently dropped.
+    """
+    return ("#!/bin/sh\n# %s\n"
+            "# In-house wrapper around the corporate LLM gateway.\n"
+            "curl -s -X POST \"$CORP_LLM_ENDPOINT/v1/completions\" \\\n"
+            "  -H 'Content-Type: application/json' \\\n"
+            "  -d \"{\\\"prompt\\\": \\\"$*\\\", \\\"max_tokens\\\": 256}\"\n" % MARKER)
+
+
+def probe_server() -> str:
+    """The trivial stdio MCP server every M-SITE row declares.
+
+    Never actually spoken to except by M-SP-01, which starts it to prove an
+    undeclared server is noticed. It exists so that the declarations point at
+    something real: a command that does not exist is a different test.
+    """
+    return ("#!/usr/bin/env node\n// %s\n"
+            "process.stdin.resume();\n"
+            "process.stdin.on('data', () => {});\n" % MARKER)
+
+
+def shell_export(variable: str, value: str) -> str:
+    return "\n# %s\nexport %s=%s\n" % (MARKER, variable, value)

--- a/Discovery/tests/install/writers.py
+++ b/Discovery/tests/install/writers.py
@@ -1,0 +1,110 @@
+"""Emitting the three config formats the declaration sites use.
+
+Only writers, never parsers. The harness composes files the collector then
+reads, so a hand-rolled writer for a subset it fully controls is safe in a way
+a hand-rolled parser would not be - and it keeps the harness on the standard
+library, which is what lets it run from this directory with nothing installed.
+
+The one exception is JSON merging, where an existing file must be read back:
+S-13 and S-16 both write ``~/.claude/settings.json``, and a writer that
+overwrote would delete the earlier entry and report it as a miss.
+"""
+
+import json
+from typing import Any, Dict, List
+
+
+def merge(base: Dict[str, Any], addition: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursive merge, with lists concatenated rather than replaced."""
+    out = dict(base)
+    for key, value in addition.items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = merge(out[key], value)
+        elif isinstance(value, list) and isinstance(out.get(key), list):
+            out[key] = out[key] + value
+        else:
+            out[key] = value
+    return out
+
+
+def as_json(document: Dict[str, Any]) -> str:
+    return json.dumps(document, indent=2, sort_keys=True) + "\n"
+
+
+def as_toml(document: Dict[str, Any]) -> str:
+    """The subset Codex's ``config.toml`` needs: nested tables of scalars.
+
+    Deliberately narrow. It emits what this manifest declares and raises on
+    anything else, because a writer that silently degrades an unsupported value
+    would produce a config the collector reads differently from the one the
+    manifest describes.
+    """
+    lines: List[str] = []
+    _toml_table(document, [], lines)
+    return "\n".join(lines) + "\n"
+
+
+def _toml_table(table: Dict[str, Any], prefix: List[str], lines: List[str]) -> None:
+    scalars = {key: value for key, value in table.items() if not isinstance(value, dict)}
+    tables = {key: value for key, value in table.items() if isinstance(value, dict)}
+    if prefix and (scalars or not tables):
+        lines.append("[%s]" % ".".join(_toml_key(part) for part in prefix))
+    for key, value in scalars.items():
+        lines.append("%s = %s" % (_toml_key(key), _toml_value(value)))
+    for key, value in tables.items():
+        if scalars or prefix:
+            lines.append("")
+        _toml_table(value, prefix + [key], lines)
+
+
+def _toml_key(key: str) -> str:
+    if key and all(character.isalnum() or character in "-_" for character in key):
+        return key
+    return json.dumps(key)
+
+
+def _toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, list):
+        return "[%s]" % ", ".join(_toml_value(item) for item in value)
+    raise TypeError("no TOML spelling for %r" % type(value).__name__)
+
+
+def as_yaml(document: Dict[str, Any]) -> str:
+    """The subset Goose's ``config.yaml`` needs: nested maps, lists of scalars.
+
+    Block style throughout, with every string quoted. Quoting unconditionally
+    costs nothing and removes the whole class of bug where a value like ``yes``
+    or ``2025-08-21`` parses as something other than the string it was written
+    as.
+    """
+    lines: List[str] = []
+    _yaml_node(document, 0, lines)
+    return "\n".join(lines) + "\n"
+
+
+def _yaml_node(node: Any, indent: int, lines: List[str]) -> None:
+    pad = "  " * indent
+    for key, value in node.items():
+        if isinstance(value, dict):
+            lines.append("%s%s:" % (pad, key))
+            _yaml_node(value, indent + 1, lines)
+        elif isinstance(value, list):
+            lines.append("%s%s:" % (pad, key))
+            for item in value:
+                lines.append("%s  - %s" % (pad, _yaml_scalar(item)))
+        else:
+            lines.append("%s%s: %s" % (pad, key, _yaml_scalar(value)))
+
+
+def _yaml_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return json.dumps(str(value))

--- a/Discovery/tests/test_writers.py
+++ b/Discovery/tests/test_writers.py
@@ -1,0 +1,95 @@
+"""Emitting the three config formats, and the content that goes in them.
+
+Pure functions with no guest anywhere near them, which makes them the part of
+the installer that can be checked exactly. A site whose shape is wrong produces
+a file the collector reads as empty - that would score as a missed site and
+blame the collector for the harness's own mistake - so the emitters are worth
+asserting on their own rather than only through a run.
+"""
+
+import json
+import unittest
+
+from .install import bodies, writers
+
+
+class Merging(unittest.TestCase):
+    def test_lists_concatenate_rather_than_replace(self):
+        """Two hook entries write one settings file; replacing would delete the
+        first and report it as a miss."""
+        merged = writers.merge({"hooks": {"PreToolUse": [{"a": 1}]}},
+                               {"hooks": {"PreToolUse": [{"b": 2}]}})
+        self.assertEqual(len(merged["hooks"]["PreToolUse"]), 2)
+
+    def test_nested_maps_merge_recursively(self):
+        merged = writers.merge({"mcpServers": {"one": {}}}, {"mcpServers": {"two": {}}})
+        self.assertEqual(sorted(merged["mcpServers"]), ["one", "two"])
+
+
+class Toml(unittest.TestCase):
+    def test_nested_tables_round_trip(self):
+        import tomllib
+        document = {"mcp_servers": {"probe": {"command": "node", "args": ["server.js"]}}}
+        self.assertEqual(tomllib.loads(writers.as_toml(document)), document)
+
+    def test_keys_that_need_quoting_get_it(self):
+        import tomllib
+        document = {"mcp_servers": {"has.a.dot": {"command": "node"}}}
+        self.assertEqual(tomllib.loads(writers.as_toml(document)), document)
+
+    def test_an_unsupported_value_raises_rather_than_degrades(self):
+        """A writer that silently dropped a value would produce a config the
+        collector reads differently from the one the manifest describes."""
+        with self.assertRaises(TypeError):
+            writers.as_toml({"a": {"b": object()}})
+
+
+class Yaml(unittest.TestCase):
+    def test_scalars_are_quoted_unconditionally(self):
+        """Quoting costs nothing and removes the class of bug where `yes` or a
+        date parses as something other than the string it was written as."""
+        text = writers.as_yaml({"extensions": {"probe": {"command": "yes"}}})
+        self.assertIn('command: "yes"', text)
+
+    def test_lists_render_as_block_items(self):
+        text = writers.as_yaml({"extensions": {"probe": {"args": ["a", "b"]}}})
+        self.assertIn('- "a"', text)
+        self.assertIn('- "b"', text)
+
+
+class Bodies(unittest.TestCase):
+    def test_every_artifact_is_marked_as_a_test_artifact(self):
+        """So nobody finds one on a machine later and wonders what it is."""
+        for text in (bodies.skill("s"), bodies.command("c"), bodies.subagent("a"),
+                     bodies.instructions("i"), bodies.backup_script(), bodies.llm_wrapper(),
+                     bodies.probe_server(), bodies.malformed_bundle()):
+            self.assertIn(bodies.MARKER, text)
+
+    def test_the_malformed_bundle_declares_nothing_runnable(self):
+        """It must be recorded as malformed, not as a server: a collector that
+        reports it as a server is inventing one."""
+        bundle = json.loads(bodies.malformed_bundle())
+        self.assertEqual(bundle["server"], {})
+        self.assertIn("manifest_version", bundle)
+
+    def test_the_lookalike_script_does_nothing_mcp_shaped(self):
+        """N-07's whole point is that "mcp" appears in its path and nowhere in
+        what it does. The comments may say so; the executable lines may not."""
+        code = [line for line in bodies.backup_script().splitlines()
+                if line.strip() and not line.strip().startswith("#")]
+        for line in code:
+            self.assertNotIn("mcp", line.lower(), line)
+
+    def test_the_wrapper_looks_like_ai_without_being_classifiable(self):
+        """N-10 must be worth reviewing and impossible to name."""
+        text = bodies.llm_wrapper()
+        self.assertIn("completions", text)
+
+    def test_a_hook_fragment_carries_its_event_and_command(self):
+        fragment = bodies.hook("PreToolUse", "audit.sh --token abc")
+        entry = fragment["hooks"]["PreToolUse"][0]["hooks"][0]
+        self.assertEqual(entry["command"], "audit.sh --token abc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #68.

The two pure halves of the installer — what a config file looks like, and what goes inside an artifact. No guest, no driver, no side effects, which makes them the part that can be checked exactly rather than only observed through a run.

## Writers only, never parsers

The harness composes files the collector then reads, so a hand-rolled writer for a subset it fully controls is safe in a way a hand-rolled parser would not be — and it keeps the harness on the standard library.

The one place a file is read back is JSON merging, and it is load-bearing: **nine launch forms share `~/.claude.json` and two hooks share `settings.json`.** A writer that wrote the file whole would leave one entry declared and the rest missing, and the run would report misses that never happened.

Two deliberate strictnesses:

- The **TOML** emitter raises on anything outside its subset rather than degrading. A silently dropped value produces a config the collector reads differently from the one the manifest describes.
- The **YAML** emitter quotes every scalar. Costs nothing, and removes the class of bug where `yes` or `2025-08-21` parses as something other than the string it was written as.

## Artifact content

Every artifact carries a marker saying it is a test artifact, so nobody finds one on a machine months later and wonders what it is. Nothing is more realistic than detection requires — a skill with a real prompt in it would be a prompt somebody could run.

Three bodies are doing specific work:

- `malformed_bundle()` — valid JSON, recognizably a bundle, declaring nothing runnable. A collector reporting it as a server is inventing one; a collector saying nothing has dropped a malformed file it should have flagged.
- `backup_script()` — `N-07`. "mcp" appears in its path and nowhere in what it does. A test asserts that of the executable lines specifically, since the comments explain the trick.
- `llm_wrapper()` — `N-10`. Must look enough like AI tooling to be worth reviewing and stay impossible to classify.

## Verification

```
$ python3 -m unittest discover -s tests -t . -q
Ran 86 tests in 0.047s
OK
```
