### PR TITLE
test(discovery): execute the manifest in dependency order

### DIFF
--- a/Discovery/tests/install/__init__.py
+++ b/Discovery/tests/install/__init__.py
@@ -1,1 +1,5 @@
 """Turning the manifest into a machine, and writing down what happened."""
+
+from .runner import Context, Runner
+
+__all__ = ["Context", "Runner"]

--- a/Discovery/tests/install/runner.py
+++ b/Discovery/tests/install/runner.py
@@ -1,0 +1,202 @@
+"""Executing the manifest, and writing down what actually happened.
+
+Two jobs, and the second is the one the scorer depends on. The runner installs
+what it can, and then records - per entry id - what the machine really ended up
+with. ``manifest.actual.json``, not the manifest, is what scoring compares
+against: an install that failed, or that a vendor no longer ships here, must
+never be scored as a miss.
+"""
+
+import json
+import os
+import posixpath
+import secrets
+import tempfile
+from typing import Any, Dict, List, Optional
+
+from ..manifest import CANARY_REF, Entry, Manifest
+from .recipes import for_family
+
+#: Entries are not independent, so execution follows dependency order rather
+#: than manifest order. Step 6 after step 3 is the subtle one: several MCP
+#: declaration sites live inside an application's own config directory, and
+#: writing M-SITE-08 before JetBrains exists creates a path the collector may
+#: treat differently from one the application itself created.
+ORDER = (
+    ("baseline-prereq",),                 # 1  already in the image, verified only
+    ("npm-global", "pipx", "vendor-binary"),  # 2  binaries on PATH
+    ("app-installer", "non-ai-app"),      # 3  VS Code must exist before its extensions
+    ("vscode-ext",),                      # 4  depends on step 3
+    ("service",),                         # 5  start, wait for port, pull model
+    ("declare-mcp",),                     # 6  config sites depend on their host app
+    ("artifact",),                        # 7  files and links
+    ("channel-variant",),                 # 8  second installs, after the first ones
+    ("scheduler", "identity"),            # 9  states that persist without a process
+    ("runtime-state",),                   # 10 last: processes must be alive at scan #2
+)
+
+
+class Context:
+    """Everything a recipe needs about the guest it is installing into."""
+
+    def __init__(self, driver: Any, manifest: Manifest, platform: str, home: str,
+                 canaries: Optional[Dict[str, str]] = None, scratch: Optional[str] = None):
+        self.driver = driver
+        self.manifest = manifest
+        self.platform = platform
+        self.home = home
+        self.canaries = canaries if canaries is not None else plant_canaries(manifest)
+        self.scratch = scratch or tempfile.mkdtemp(prefix="adr-e2e-")
+
+    def expand(self, path: Optional[str]) -> str:
+        """Resolve the manifest's spelling of home into this guest's."""
+        if not path:
+            return ""
+        text = str(path).replace("~", self.home).replace("%USERPROFILE%", self.home)
+        return text.replace("%APPDATA%", posixpath.join(self.home, "AppData/Roaming"))
+
+    def path_for(self, entry: Entry, site: Optional[str] = None) -> str:
+        """Where this entry writes on this OS, absolute.
+
+        Only the M-SITE rows carry a path, because they are the rows whose
+        subject *is* the path. Every other declaration - the nine launch forms,
+        the special cases - says which site it declares in and inherits that
+        site's file, so the location of a config file is stated once and a
+        vendor moving it is a one-line change.
+        """
+        own = entry.path_for(self.platform)
+        if own and not site:
+            return self.expand(own)
+        site = site or entry.declare.get("site")
+        if not site:
+            return self.expand(own)
+        owner = _site_owner(self.manifest, site)
+        return self.expand(self.manifest.by_id(owner).path_for(self.platform))
+
+    def substitute(self, value: Any) -> Any:
+        """Replace ``{{canary:name}}`` with this run's value for that canary.
+
+        Substituted here rather than in each recipe so a credential exists in
+        exactly one place: the run directory. A recipe that built its own would
+        plant a value the redaction check never searches for, and the run would
+        report a clean check it never made.
+        """
+        if not isinstance(value, str):
+            return value
+        return CANARY_REF.sub(lambda match: self.canaries.get(match.group(1), match.group(0)), value)
+
+    def scratch_file(self, remote: str) -> str:
+        return os.path.join(self.scratch, remote.replace("/", "_").replace(":", "_"))
+
+
+class Runner:
+    """One pass over the applicable manifest, in dependency order."""
+
+    def __init__(self, context: Context):
+        self.context = context
+        self.outcomes: List[Dict[str, Any]] = []
+
+    def run(self) -> Dict[str, Any]:
+        entries = self.context.manifest.for_platform(self.context.platform)
+        self._prepare(entries)
+        for family_group in ORDER:
+            for entry in [item for item in entries if item.family in family_group]:
+                self.outcomes.append(self._execute(entry))
+        self._propagate_dependencies()
+        return self.actual()
+
+    def _execute(self, entry: Entry) -> Dict[str, Any]:
+        recipe = for_family(entry.family)
+        try:
+            outcome = recipe.execute(self.context, entry)
+        except Exception as exc:  # a recipe that raises must not take the run with it
+            return {"id": entry.id, "status": "failed", "family": entry.family,
+                    "catalog_id": entry.catalog_id,
+                    "reason": "%s: %s" % (exc.__class__.__name__, exc)}
+        return outcome.to_dict()
+
+    def _prepare(self, entries: List[Entry]) -> None:
+        """Create what the manifest's declarations point at.
+
+        Every M-SITE row declares a server whose command is a real file. A
+        declaration pointing at a command that does not exist is a different
+        test from the one the manifest describes, and the collector is entitled
+        to treat the two differently.
+        """
+        from .. import install  # local import keeps the module import graph acyclic
+        del install
+        from .bodies import probe_server
+        needed = {self.context.expand("~/dev/tools/adr-probe-server.js"): probe_server(),
+                  self.context.expand("~/dev/tools/my-server.js"): probe_server()}
+        for path, content in needed.items():
+            self.context.driver.write(path, content)
+
+    def _propagate_dependencies(self) -> None:
+        """An entry whose dependency never installed was never really attempted.
+
+        Recorded ``unimplemented`` rather than ``failed``: the entry did not
+        fail, the thing it needed was never there. Scoring it as a miss would
+        blame the collector for the harness's own gap - and a variant of a tool
+        that was never installed once proves nothing about duplication.
+        """
+        status = {row["id"]: row["status"] for row in self.outcomes}
+        for row in self.outcomes:
+            entry = self.context.manifest.by_id(row["id"])
+            blockers = [item for item in list(entry.depends_on) +
+                        ([entry.variant_of] if entry.variant_of else [])
+                        if status.get(item) not in ("installed", None)]
+            if blockers and row["status"] == "installed":
+                row["status"] = "unimplemented"
+                row["reason"] = "depends on %s, which is %s" % (blockers[0], status[blockers[0]])
+
+    def actual(self) -> Dict[str, Any]:
+        counts: Dict[str, int] = {}
+        for row in self.outcomes:
+            counts[row["status"]] = counts.get(row["status"], 0) + 1
+        return {
+            "os": self.context.platform,
+            "home": self.context.home,
+            "image": getattr(self.context.driver, "image", ""),
+            "applicable": len(self.context.manifest.for_platform(self.context.platform)),
+            "installed": counts.get("installed", 0),
+            "unavailable": counts.get("unavailable", 0),
+            "failed": counts.get("failed", 0),
+            "unimplemented": counts.get("unimplemented", 0),
+            "entries": self.outcomes,
+        }
+
+
+def plant_canaries(manifest: Manifest) -> Dict[str, str]:
+    """Generate this run's credential values from the declared shapes.
+
+    Fresh per run and never committed: a credential checked into a repository is
+    a credential, even a fake one. The shapes mirror real vendor formats closely
+    enough to exercise shape-driven redaction, and every one carries a marker no
+    issuer emits so it can never be mistaken for a live key.
+    """
+    values = {}
+    for declaration in manifest.canaries:
+        shape = declaration["shape"]
+        if "{random:" in shape:
+            width = int(shape.split("{random:")[1].split("}")[0])
+            shape = shape.split("{random:")[0] + secrets.token_hex(width)[:width] + \
+                shape.split("}", 1)[1] if "}" in shape else shape
+        values[declaration["name"]] = shape
+    return values
+
+
+def _site_owner(manifest: Manifest, site: str) -> str:
+    """The M-SITE row that owns a config file, so a multi-site entry can reuse it."""
+    for entry in manifest:
+        if entry.declare.get("site") == site:
+            return entry.id
+    raise KeyError(site)
+
+
+def write_actual(actual: Dict[str, Any], run_dir: str) -> str:
+    os.makedirs(run_dir, exist_ok=True)
+    path = os.path.join(run_dir, "manifest.actual.json")
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(actual, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    return path

--- a/Discovery/tests/test_runner.py
+++ b/Discovery/tests/test_runner.py
@@ -1,0 +1,199 @@
+"""The runner is as much of the harness as the scorer, and much harder to test:
+it exists to mutate a machine. The dry driver makes the mutation inspectable,
+so the ordering rules, the canary substitution and the recorded outcomes can be
+asserted with no hypervisor anywhere near them."""
+
+import json
+import unittest
+
+from . import manifest as manifest_module
+from .install import Context, Runner
+from .install.recipes import PENDING, REGISTRY, for_family
+from .install.runner import ORDER
+from .provision import DryRunDriver
+
+HOME = "/home/tester"
+
+
+class DryLinuxRun(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+        cls.driver = DryRunDriver("linux", HOME)
+        cls.context = Context(cls.driver, cls.manifest, "linux", HOME)
+        cls.actual = Runner(cls.context).run()
+        cls.rows = {row["id"]: row for row in cls.actual["entries"]}
+
+    def test_every_applicable_entry_gets_an_outcome(self):
+        """An entry with no row is an entry nobody can score, in either
+        direction."""
+        self.assertEqual(len(self.rows), 105)
+        self.assertEqual(self.actual["applicable"], 105)
+
+    def test_nothing_fails_on_a_healthy_guest(self):
+        failures = [row for row in self.actual["entries"] if row["status"] == "failed"]
+        self.assertEqual(failures, [], failures)
+
+    def test_the_three_implemented_families_install(self):
+        for entry_id in ("T-CLI-01", "M-SITE-01", "M-PIN-06", "S-01", "S-16", "N-10"):
+            self.assertEqual(self.rows[entry_id]["status"], "installed", entry_id)
+
+    def test_a_family_with_no_recipe_is_unimplemented_not_failed(self):
+        """A recipe nobody has written must never be reported as a vendor that
+        stopped shipping or a collector that missed something."""
+        row = self.rows["T-APP-02"]
+        self.assertEqual(row["status"], "unimplemented")
+        self.assertIn("app-installer", row["reason"])
+
+    def test_an_entry_whose_dependency_never_installed_is_not_attempted(self):
+        row = self.rows["M-SITE-03"]
+        self.assertEqual(row["status"], "unimplemented")
+        self.assertIn("T-APP-02", row["reason"])
+
+    def test_counts_add_up(self):
+        total = (self.actual["installed"] + self.actual["unavailable"]
+                 + self.actual["failed"] + self.actual["unimplemented"])
+        self.assertEqual(total, self.actual["applicable"])
+
+    def test_the_run_records_where_home_was(self):
+        """Without it the scorer cannot compare a manifest path against a
+        recorded one, and every artifact entry scores as a miss."""
+        self.assertEqual(self.actual["home"], HOME)
+
+
+class Ordering(unittest.TestCase):
+    def test_config_sites_are_written_after_their_host_applications(self):
+        """Writing M-SITE-08 before JetBrains exists creates a path the
+        collector may treat differently from one the application created."""
+        families = [family for group in ORDER for family in group]
+        self.assertLess(families.index("app-installer"), families.index("declare-mcp"))
+        self.assertLess(families.index("app-installer"), families.index("vscode-ext"))
+
+    def test_second_installs_come_after_first_ones(self):
+        families = [family for group in ORDER for family in group]
+        self.assertLess(families.index("npm-global"), families.index("channel-variant"))
+
+    def test_running_processes_are_left_until_last(self):
+        """They must still be alive at the second scan."""
+        self.assertEqual(ORDER[-1], ("runtime-state",))
+
+    def test_every_family_is_ordered_exactly_once(self):
+        families = [family for group in ORDER for family in group]
+        self.assertEqual(sorted(families), sorted(manifest_module.FAMILIES))
+        self.assertEqual(len(families), len(set(families)))
+
+    def test_every_family_resolves_to_a_recipe_or_a_stated_gap(self):
+        for family in manifest_module.FAMILIES:
+            self.assertTrue(family in REGISTRY or family in PENDING, family)
+            self.assertIsNotNone(for_family(family))
+
+
+class Canaries(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+        cls.driver = DryRunDriver("linux", HOME)
+        cls.context = Context(cls.driver, cls.manifest, "linux", HOME)
+        Runner(cls.context).run()
+
+    def test_a_value_is_generated_for_every_declared_canary(self):
+        self.assertEqual(sorted(self.context.canaries), sorted(self.manifest.canary_names()))
+
+    def test_values_are_planted_not_placeholders(self):
+        """A recipe that built its own would plant a value the redaction check
+        never searches for."""
+        config = json.loads(self.driver.files[HOME + "/.claude.json"])
+        args = config["mcpServers"]["adr-probe-argv-token"]["args"]
+        self.assertIn(self.context.canaries["mcp_token"], args)
+        self.assertNotIn("{{canary:mcp_token}}", args)
+
+    def test_two_vendor_shapes_are_planted_in_env(self):
+        """Redaction is partly shape-driven, so one shape passing proves only
+        that one shape passes."""
+        config = json.loads(self.driver.files[HOME + "/.claude.json"])
+        env = config["mcpServers"]["adr-probe-env-key"]["env"]
+        self.assertTrue(env["ANTHROPIC_API_KEY"].startswith("sk-ant-api03-"))
+        self.assertTrue(env["OPENAI_API_KEY"].startswith("sk-proj-"))
+
+    def test_each_canary_carries_a_marker_no_issuer_emits(self):
+        for name, value in self.context.canaries.items():
+            self.assertIn("ADRE2ECANARY" if value.startswith("sk-") else "adr-e2e-canary",
+                          value, name)
+
+
+class WritingConfigs(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+        cls.driver = DryRunDriver("linux", HOME)
+        Runner(Context(cls.driver, cls.manifest, "linux", HOME)).run()
+
+    def test_nine_launch_forms_share_one_file_without_overwriting_it(self):
+        """A recipe that wrote the file whole would leave one server declared
+        and eight missing, and the run would report eight misses that never
+        happened."""
+        config = json.loads(self.driver.files[HOME + "/.claude.json"])
+        for name in ("filesystem", "git", "github", "sqlite", "fetch", "memory",
+                     "playwright", "local-script", "remote-sse"):
+            self.assertIn(name, config["mcpServers"], name)
+
+    def test_each_site_gets_the_format_that_site_uses(self):
+        self.assertIn("[mcp_servers", self.driver.files[HOME + "/.codex/config.toml"])
+        self.assertIn("extensions:", self.driver.files[HOME + "/.config/goose/config.yaml"])
+
+    def test_two_hooks_in_one_settings_file_both_survive(self):
+        settings = json.loads(self.driver.files[HOME + "/.claude/settings.json"])
+        commands = [hook["command"] for group in settings["hooks"]["PreToolUse"]
+                    for hook in group["hooks"]]
+        self.assertEqual(len(commands), 2)
+
+    def test_the_declared_command_exists_on_disk(self):
+        """A declaration whose command is absent is a different test from the
+        one the manifest describes."""
+        self.assertIn(HOME + "/dev/tools/adr-probe-server.js", self.driver.files)
+
+    def test_the_dangling_symlink_is_left_dangling(self):
+        """And created as root: /usr/local/bin is not the user's to write."""
+        commands = [" ".join(argv) for argv in self.driver.commands]
+        self.assertIn("sudo -n ln -sfn /opt/removed/claude /usr/local/bin/claude-old", commands)
+
+    def test_managed_policy_is_written_as_root(self):
+        """A policy file a user could write would not be policy. A transport
+        that does not elevate writes it as the user - or not at all - and the
+        run then reports the site as missing."""
+        self.assertIn("/etc/claude-code/managed-settings.json", self.driver.privileged_writes)
+        self.assertIn("/etc/adr/managed-mcp.json", self.driver.privileged_writes)
+
+    def test_an_artifact_that_did_not_land_is_a_failure_not_an_install(self):
+        """The worst failure this harness can have is manufacturing a defect in
+        the thing it measures: a write that silently did not land, recorded as
+        installed, reads as the collector missing a file that was never there."""
+        from .install.recipes.artifact import ArtifactRecipe
+        from .provision import DryRunDriver
+
+        class Sink(DryRunDriver):
+            def write(self, remote, content, privileged=False):
+                pass          # a transport that quietly drops the write
+
+        manifest = manifest_module.load()
+        driver = Sink("linux", HOME)
+        context = Context(driver, manifest, "linux", HOME)
+        outcome = ArtifactRecipe().execute(context, manifest.by_id("S-01"))
+        self.assertEqual(outcome.status, "failed")
+        self.assertIn("not there afterwards", outcome.reason)
+
+
+class OtherPlatforms(unittest.TestCase):
+    def test_windows_and_mac_run_with_their_own_paths(self):
+        manifest = manifest_module.load()
+        for platform, home, marker in (("mac", "/Users/tester", "/Users/tester/.zshrc"),
+                                       ("win", "C:/Users/tester",
+                                        "C:/Users/tester/.codex/config.toml")):
+            driver = DryRunDriver(platform, home)
+            actual = Runner(Context(driver, manifest, platform, home)).run()
+            self.assertEqual(actual["applicable"], len(manifest.for_platform(platform)))
+            self.assertIn(marker, driver.files)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #70.

Two jobs, and the second is what the scorer depends on. The runner installs what it can, then records **per entry id what the machine really ended up with**. `manifest.actual.json`, not the manifest, is what scoring compares against — an install that failed, or that a vendor no longer ships here, must never be scored as a miss.

## Dependency order, not manifest order

```
1 baseline-prereq          already in the image, verified only
2 npm / pipx / bin         binaries on PATH
3 app-installer            VS Code must exist before its extensions
4 vscode-ext               depends on 3
5 service                  start, wait for port, pull model
6 declare-mcp              config sites depend on their host app
7 artifact                 files and links
8 channel-variant          second installs, after the first ones
9 scheduler / identity     states that persist without a process
10 runtime-state           last: processes must be alive at scan #2
```

Step 6 after step 3 is the subtle one. Several MCP declaration sites live inside an application's own config directory, and writing `M-SITE-08` before JetBrains exists creates a path the collector may treat differently from one the application itself created.

## Blocked entries are `unimplemented`, not `failed`

The entry did not fail; the thing it needed was never there. Scoring it as a miss would blame the collector for the harness's own gap — and a second install of a tool that was never installed once proves nothing about duplication.

## Canaries are substituted in one place

Generated once per run, applied here rather than in each recipe, so a credential exists in exactly one place: the run directory. A recipe that built its own would plant a value the redaction check never searches for, and the run would report a clean check it never made.

## Verification

Dry guest, all three platforms:

```
linux  applicable=105 installed=52 failed=0 unimplemented=53 files=40
mac    applicable=110 installed=51 failed=0 unimplemented=59 files=40
win    applicable=103 installed=51 failed=1 unimplemented=51 files=39
```

```
$ python3 -m unittest discover -s tests -t . -q
Ran 110 tests in 0.076s
OK
```

### The one Windows failure is a real finding, left visible

```
N-09 | wrote /usr/local/bin/claude-old but it is not there afterwards
```

`N-09` is specified as a dangling symlink at `/usr/local/bin/claude-old` and marked applicable on all three platforms, but that path is POSIX-only — the entry cannot exist on Windows as written. Every other per-OS path in the manifest is a three-way mapping; this one is a bare string, inherited from the way the row is written in `tests/README.md`.

It is left failing rather than papered over, because the failure is the harness correctly reporting that it could not do what it was asked. Fixing it means deciding what the Windows equivalent is — a broken shortcut on `PATH`, most likely — which is a manifest change and belongs with the Windows work, where it can actually be validated. Windows is unvalidated in this series either way; see #68 on why no QEMU driver ships here.

## Live results

These recipes, this runner, against a real Ubuntu 24.04 aarch64 guest:

```
105 applicable · 52 installed · 0 failed · 53 unimplemented   (61s)
```

Verified on the guest rather than from the runner's own report: 8 CLI binaries on `PATH` at their pinned versions, 12/12 config sites written, `/etc/claude-code/managed-settings.json` owned `root:root`, `N-09`'s link present and dangling, 28 artifact files.
