### PR TITLE
fix(discovery): resolve declaration site paths at manifest load

### DIFF
--- a/Discovery/tests/manifest.py
+++ b/Discovery/tests/manifest.py
@@ -161,9 +161,37 @@ def load(directory: str = MANIFEST_DIR) -> "Manifest":
             entries.append(_entry(row, source=name))
     canaries = _load_side_file(directory, "canaries.toml", "canaries")
     sources = _load_side_file(directory, "sources.toml", "sources")
+    _resolve_sites(entries)
     manifest = Manifest(entries=entries, canaries=canaries, sources=sources)
     manifest.validate()
     return manifest
+
+
+def _resolve_sites(entries: List[Entry]) -> None:
+    """Give every declaration a path, using the sites that already name one.
+
+    The fourteen M-SITE rows enumerate the declaration sites and where each one
+    lives per OS. The pinned and special-case rows reuse those sites by name and
+    carry no path of their own, so without this they would be unwritable by the
+    runner and unmatchable by the scorer for reasons that have nothing to do
+    with the collector.
+    """
+    known: Dict[str, Dict[str, str]] = {}
+    for entry in entries:
+        site = entry.declare.get("site")
+        path = entry.declare.get("path")
+        if site and isinstance(path, dict):
+            known.setdefault(str(site), {}).update({k: v for k, v in path.items() if v})
+
+    for entry in entries:
+        if not entry.declare or entry.declare.get("path"):
+            continue
+        names = entry.declare.get("sites") or [entry.declare.get("site")]
+        for name in names:
+            resolved = known.get(str(name))
+            if resolved:
+                entry.declare["path"] = dict(resolved)
+                break
 
 
 def _load_side_file(directory: str, name: str, key: str) -> Any:


### PR DESCRIPTION
## What

Thirteen MCP rows name a declaration site and a launch form but carry no path of their own. `manifest.load()` now fills that path in from the row that does declare one.

## Why

The fourteen `M-SITE-*` rows enumerate the declaration sites and where each lives per OS. The `M-PIN-*` rows reuse those sites by name, and `M-SP-02` deliberately spans two of them via `sites` rather than `site`.

Left unresolved, those rows have **no location at all** — so a runner cannot write them and a scorer cannot match them, for reasons that have nothing to do with the collector under test. On Linux that is the difference between 51 and 64 executable entries.

## How

`_resolve_sites()` builds a site → per-OS path map from the rows that declare one, then fills it into rows that name a site and lack a path. It runs before `validate()`, so invariant checks see resolved rows.

Two deliberate choices:

- **In the loader, not in each consumer.** The runner, the scorer and the synthesizer all need the same answer; resolving once means they cannot disagree about where a declaration lives.
- **Fills gaps only.** A row stating its own path keeps it — `M-SITE-01` still resolves to `~/.claude.json`.

## Tests

Five added to `test_manifest.py`, covering the gap this change opened: every declaration resolves a path somewhere, a pinned row inherits its site's path, a row with its own path keeps it, a multi-site row resolves, and resolution stays per-platform.

```
$ python3 -m unittest tests.test_manifest
Ran 14 tests in 0.011s
OK
```

Additive only — no existing line changed, and no dependency beyond the standard library.