### PR TITLE
test(discovery): add harness unit tests

### DIFF
--- a/Discovery/tests/test_bootstrap.py
+++ b/Discovery/tests/test_bootstrap.py
@@ -1,0 +1,134 @@
+"""Provisioning is asserted against a dry guest, because the bugs were in the
+translation from manifest row to shell command - not in the guests."""
+
+import json
+import unittest
+
+from . import manifest as manifest_module
+from .install.bodies import artifact, body_for
+from .provision.driver import DryDriver
+from .tools import bootstrap
+
+
+class Bodies(unittest.TestCase):
+    """`body` names a template. Writing the name leaves a file that says nothing."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+
+    def test_a_skill_is_a_skill_and_not_the_word_skill(self):
+        text = artifact(self.manifest.by_id("S-01"))
+        self.assertNotEqual(text.strip(), "skill")
+        self.assertIn("name:", text)
+
+    def test_a_hook_row_produces_the_settings_shape(self):
+        document = json.loads(artifact(self.manifest.by_id("S-13")))
+        self.assertIn("PreToolUse", document["hooks"])
+        commands = [inner["command"]
+                    for group in document["hooks"]["PreToolUse"]
+                    for inner in group["hooks"]]
+        self.assertTrue(any("audit.sh" in c for c in commands))
+
+    def test_a_canary_reaches_the_body(self):
+        text = body_for(self.manifest.by_id("S-16"), {"hook_token": "adr-e2e-canary-hook-XYZ"})
+        self.assertIn("adr-e2e-canary-hook-XYZ", text)
+        self.assertNotIn("{{canary:", text)
+
+    def test_an_unresolved_canary_is_left_visible(self):
+        """Blanking it would turn a hole in the check into a passing check."""
+        text = body_for(self.manifest.by_id("S-16"), {})
+        self.assertIn("{{canary:hook_token}}", text)
+
+    def test_the_malformed_bundle_is_actually_malformed(self):
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(artifact(self.manifest.by_id("M-SP-06")))
+
+    def test_every_template_marker_is_known(self):
+        """A marker with no template silently becomes a comment."""
+        from .install.bodies import TEMPLATES
+
+        unknown = set()
+        for entry in self.manifest:
+            marker = str(entry.create.get("body") or "")
+            if marker and marker not in TEMPLATES and marker not in ("hook", "malformed_bundle",
+                                                                     "shell_export"):
+                unknown.add(marker)
+        self.assertEqual(unknown, set())
+
+
+class Provisioning(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+
+    def test_an_unattended_family_is_skipped_with_a_reason(self):
+        """Silently succeeding would make the environment look ready when it is not."""
+        report = bootstrap.provision(DryDriver(), "linux", manifest=self.manifest, log=lambda m: None)
+        skipped = report.of(bootstrap.SKIPPED)
+        self.assertTrue(skipped)
+        self.assertTrue(all(step.detail for step in skipped))
+
+    def test_a_path_outside_home_is_written_as_root(self):
+        """A managed policy site lives under /etc whether or not the row says so."""
+        driver = DryDriver()
+        bootstrap.provision(driver, "linux", manifest=self.manifest,
+                            only=("declare-mcp",), log=lambda m: None)
+        etc = [c for c in driver.commands if "/etc/" in " ".join(c)]
+        self.assertTrue(etc)
+        self.assertTrue(all("sudo" in " ".join(c) for c in etc))
+
+    def test_an_append_row_appends_rather_than_replaces(self):
+        driver = DryDriver()
+        bootstrap.provision(driver, "linux", manifest=self.manifest,
+                            only=("artifact",), log=lambda m: None)
+        profile = [" ".join(c) for c in driver.commands if ".bashrc" in " ".join(c)]
+        self.assertTrue(profile)
+        self.assertTrue(any(">>" in line for line in profile))
+        self.assertFalse(any("cat > " in line and ".bashrc" in line for line in profile))
+
+    def test_a_directory_row_makes_a_directory(self):
+        driver = DryDriver()
+        bootstrap.provision(driver, "linux", manifest=self.manifest,
+                            only=("artifact",), log=lambda m: None)
+        plugin = [" ".join(c) for c in driver.commands if "acme-tools" in " ".join(c)]
+        self.assertTrue(any("mkdir -p" in line for line in plugin))
+
+    def test_a_prerequisite_is_verified_by_binary_not_by_display_name(self):
+        """`command -v "Node.js"` fails on a machine that has node."""
+        driver = DryDriver()
+        bootstrap.provision(driver, "linux", manifest=self.manifest,
+                            only=("baseline-prereq",), log=lambda m: None)
+        joined = " ".join(" ".join(c) for c in driver.commands)
+        self.assertIn("node", joined)
+        self.assertNotIn("Node.js", joined)
+
+    def test_ready_is_false_while_anything_failed(self):
+        report = bootstrap.Report("linux", [bootstrap.Step("X", "x", "f", bootstrap.FAILED)])
+        self.assertFalse(report.ready)
+
+    def test_skipped_alone_does_not_block_ready(self):
+        report = bootstrap.Report("linux", [bootstrap.Step("X", "x", "f", bootstrap.SKIPPED, "why")])
+        self.assertTrue(report.ready)
+
+
+class Merging(unittest.TestCase):
+    def test_a_nested_list_is_extended_rather_than_replaced(self):
+        """Two hook rows land on one event; a shallow update keeps only the last."""
+        current = {"hooks": {"PreToolUse": [{"hooks": [{"command": "a"}]}]}}
+        incoming = {"hooks": {"PreToolUse": [{"hooks": [{"command": "b"}]}]}}
+        merged = bootstrap._deep_merge(current, incoming)
+        self.assertEqual(len(merged["hooks"]["PreToolUse"]), 2)
+
+    def test_an_identical_entry_is_not_duplicated(self):
+        one = {"hooks": {"PreToolUse": [{"hooks": [{"command": "a"}]}]}}
+        merged = bootstrap._deep_merge(one, json.loads(json.dumps(one)))
+        self.assertEqual(len(merged["hooks"]["PreToolUse"]), 1)
+
+    def test_unrelated_keys_survive(self):
+        merged = bootstrap._deep_merge({"model": "opus", "hooks": {}}, {"hooks": {"X": []}})
+        self.assertEqual(merged["model"], "opus")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Discovery/tests/test_canary.py
+++ b/Discovery/tests/test_canary.py
@@ -1,0 +1,51 @@
+"""A leaked credential fails the run, so the leak check is asserted first."""
+
+import unittest
+
+from .scoring import canary
+
+
+class Leaks(unittest.TestCase):
+    def test_a_planted_value_in_the_output_is_a_leak(self):
+        report = canary.check(
+            {"hook_token": "adr-e2e-canary-hook-000000000000"},
+            {"after.json": '{"proof": "adr-e2e-canary-hook-000000000000"}'},
+        )
+        self.assertFalse(report.clean)
+        self.assertEqual(report.leaked, 1)
+        self.assertEqual(report.leaks[0].name, "hook_token")
+        self.assertEqual(report.leaks[0].where, "after.json")
+
+    def test_a_redacted_output_is_clean(self):
+        report = canary.check(
+            {"hook_token": "adr-e2e-canary-hook-000000000000"},
+            {"after.json": '{"proof": "[redacted]"}'},
+        )
+        self.assertTrue(report.clean)
+        self.assertEqual(report.planted, 1)
+
+    def test_a_short_canary_is_refused_rather_than_reported(self):
+        """A value short enough to collide would report a leak that is not one."""
+        with self.assertRaises(canary.CanaryError):
+            canary.check({"tiny": "abc"}, {"after.json": "abc"})
+
+    def test_declared_but_never_planted_is_reported(self):
+        """A canary nobody planted is a hole in the check, not a pass."""
+        report = canary.check(
+            {"hook_token": "adr-e2e-canary-hook-000000000000"},
+            {"after.json": "{}"},
+            declared=["hook_token", "env_key"],
+        )
+        self.assertTrue(report.clean)
+        self.assertEqual(report.unplanted, ("env_key",))
+
+    def test_every_document_is_searched(self):
+        report = canary.check(
+            {"a": "adr-e2e-canary-aaaaaaaaaaaa"},
+            {"before.json": "{}", "after.json": "adr-e2e-canary-aaaaaaaaaaaa"},
+        )
+        self.assertEqual([leak.where for leak in report.leaks], ["after.json"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Discovery/tests/test_match.py
+++ b/Discovery/tests/test_match.py
@@ -1,0 +1,107 @@
+"""Matching is where a harness invents defects, so each rule is asserted alone."""
+
+import unittest
+
+from adr_discovery.contracts.records import Asset, Kind
+
+from . import manifest as manifest_module
+from .scoring.match import identity_of, launch_identity, match, normalize_path
+
+
+def asset(asset_id, **kw):
+    kw.setdefault("kind", Kind.CLI_AGENT)
+    kw.setdefault("name", asset_id)
+    kw.setdefault("identity", asset_id)
+    return Asset(asset_id=asset_id, **kw)
+
+
+class Normalization(unittest.TestCase):
+    def test_a_home_reference_becomes_a_path(self):
+        self.assertEqual(normalize_path("~/.claude.json", "/root"), "/root/.claude.json")
+        self.assertEqual(normalize_path("%USERPROFILE%/x", "/users/a"), "/users/a/x")
+
+    def test_windows_separators_compare_with_posix_ones(self):
+        self.assertEqual(normalize_path(r"C:\Users\a\x"), normalize_path("C:/Users/a/x"))
+
+    def test_launch_identity_ignores_formatting(self):
+        """`docker run x` declared by two people is one server, not two."""
+        self.assertEqual(
+            launch_identity("docker", ["run", "mcp/memory:latest"]),
+            launch_identity("/usr/bin/docker", ["run", "  mcp/memory:latest "]),
+        )
+
+    def test_an_empty_path_stays_empty(self):
+        self.assertEqual(normalize_path(None), "")
+
+
+class Claiming(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+
+    def test_an_asset_is_claimed_once(self):
+        """Two rows at one path must not both report success for one asset."""
+        rows = [self.manifest.by_id("S-01"), self.manifest.by_id("S-02")]
+        one = asset("only", install_path=rows[0].path_for("linux"))
+        result = match(rows, [one], platform="linux")
+        claimed = [m for m in result.matches if m.assets]
+        self.assertEqual(len(claimed), 1)
+
+    def test_an_asset_indexed_by_two_paths_is_not_its_own_duplicate(self):
+        """install_path and install_root are often the same file."""
+        row = self.manifest.by_id("S-01")
+        path = row.path_for("linux")
+        result = match([row], [asset("a", install_path=path, install_root=path)], platform="linux")
+        self.assertEqual(result.matches[0].assets, ("a",))
+
+    def test_a_surplus_asset_at_a_shared_key_is_a_duplicate(self):
+        row = self.manifest.by_id("S-01")
+        path = row.path_for("linux")
+        result = match([row], [asset("a", install_path=path), asset("b", install_path=path)],
+                       platform="linux")
+        self.assertEqual(len(result.matches[0].assets), 2)
+
+    def test_an_unmatched_asset_is_left_over(self):
+        row = self.manifest.by_id("S-01")
+        result = match([row], [asset("stranger", install_path="/nowhere")], platform="linux")
+        self.assertIn("stranger", result.unmatched_assets)
+
+
+class Shapes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+
+    def test_a_variant_claims_nothing(self):
+        """Two installs of one tool must yield one asset, not two."""
+        variants = [e for e in self.manifest if e.variant_of]
+        self.assertTrue(variants)
+        result = match(variants, [asset("x")], platform="linux")
+        self.assertTrue(all(m.assets == () for m in result.matches))
+
+    def test_an_assertion_does_not_consume_the_asset_it_describes(self):
+        """AG-08 asserts a property of the tool T-CLI-01 installed."""
+        tool = self.manifest.by_id("T-CLI-01")
+        claim = self.manifest.by_id("AG-08")
+        found = asset("claude", catalog_id="claude-code")
+        result = match([tool, claim], [found], platform="linux")
+        self.assertEqual(result.for_entry("T-CLI-01").assets, ("claude",))
+        self.assertEqual(result.for_entry("AG-08").assets, ("claude",))
+        self.assertEqual(result.unmatched_assets, ())
+
+    def test_a_remote_server_is_identified_by_where_it_points(self):
+        """M-PIN-09 launches nothing, so a launch identity would be empty."""
+        entry = self.manifest.by_id("M-PIN-09")
+        self.assertTrue(identity_of(entry, platform="linux"))
+
+    def test_the_same_command_at_two_sites_is_two_assets(self):
+        """Fourteen M-SITE rows share one command and differ only by site."""
+        sites = [e for e in self.manifest if e.id.startswith("M-SITE-")]
+        keys = {identity_of(e, platform="linux") for e in sites}
+        self.assertEqual(len(keys), 1, "these rows deliberately share a launch identity")
+        result = match(sites, [], platform="linux")
+        self.assertEqual(len({m.key for m in result.matches}), len(sites))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Discovery/tests/test_report.py
+++ b/Discovery/tests/test_report.py
@@ -1,0 +1,79 @@
+"""The scorecard exists to be read, so what it must contain is asserted."""
+
+import os
+import unittest
+
+from . import manifest as manifest_module
+from .report import html
+from .scoring import schema, snapshot
+from .scoring.score import score
+
+RECORDED = os.path.join(os.path.dirname(os.path.abspath(__file__)), "recorded", "synthetic-linux")
+
+
+class Scorecard(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.score = score(snapshot.load(RECORDED), manifest_module.load())
+        cls.page = html.render(cls.score, schema.gate(cls.score))
+
+    def test_it_is_one_self_contained_page(self):
+        """No external assets: a scorecard travels as a file."""
+        self.assertTrue(self.page.startswith("<!doctype html>"))
+        self.assertNotIn("http://", self.page)
+        self.assertNotIn("<script", self.page)
+
+    def test_it_names_the_run_the_image_and_the_collector(self):
+        """A scoring shift must be attributable to the image or the collector."""
+        for expected in (self.score.run_id, self.score.image, self.score.collector):
+            self.assertIn(html.esc(expected), self.page)
+
+    def test_it_reports_the_gate(self):
+        self.assertIn("PASS", self.page)
+
+    def test_categories_are_listed_separately(self):
+        for category in self.score.by_category:
+            self.assertIn(html.esc(category), self.page)
+
+
+class Failures(unittest.TestCase):
+    def test_every_miss_and_invention_is_listed_by_id(self):
+        """The aggregate is for tracking; the rows are what somebody fixes."""
+        import tempfile
+
+        from .tools import synthesize
+
+        directory = tempfile.mkdtemp()
+        synthesize.build(directory, plan=synthesize.Plan(platform="linux",
+                                                        faults=("miss", "invent")))
+        result = score(snapshot.load(directory), manifest_module.load())
+        page = html.render(result, schema.gate(result))
+
+        self.assertTrue(result.misses and result.inventions)
+        for verdict in result.misses:
+            self.assertIn(html.esc(verdict.entry_id), page)
+        for verdict in result.inventions:
+            self.assertIn(html.esc(verdict.entry_id), page)
+
+    def test_a_failing_gate_says_why(self):
+        import tempfile
+
+        from .tools import synthesize
+
+        directory = tempfile.mkdtemp()
+        synthesize.build(directory, plan=synthesize.Plan(platform="linux", faults=("leak",)))
+        result = score(snapshot.load(directory), manifest_module.load())
+        gate = schema.gate(result)
+        page = html.render(result, gate)
+
+        self.assertIn("FAIL", page)
+        for reason in gate.reasons:
+            self.assertIn(html.esc(reason), page)
+
+    def test_content_is_escaped(self):
+        """Asset names come from the machine under test, not from us."""
+        self.assertNotIn("<script>", html.esc("<script>alert(1)</script>"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Discovery/tests/test_runner.py
+++ b/Discovery/tests/test_runner.py
@@ -1,0 +1,106 @@
+"""Execution order is the runner's whole job, so it is asserted directly."""
+
+import unittest
+
+from . import manifest as manifest_module
+from .install import runner
+from .install.recipes import BUILT, PENDING, REGISTRY
+from .provision.driver import DryDriver
+
+
+class Order(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+
+    def test_every_family_has_an_execution_slot(self):
+        families = {entry.family for entry in self.manifest}
+        self.assertEqual(families - set(runner.ORDER), set())
+
+    def test_a_family_with_no_slot_is_refused(self):
+        """Silently appending it would run it in an order nobody chose."""
+        entry = self.manifest.by_id("T-CLI-01")
+        entry = type(entry)(**{**entry.__dict__, "family": "invented"})
+        with self.assertRaises(runner.UnknownFamily):
+            runner.ordered([entry])
+
+    def test_extensions_run_after_the_app_that_hosts_them(self):
+        self.assertLess(runner.ORDER.index("app-installer"), runner.ORDER.index("vscode-ext"))
+
+    def test_declarations_run_after_their_host_application(self):
+        """A config path created before the app exists may be read differently."""
+        self.assertLess(runner.ORDER.index("app-installer"), runner.ORDER.index("declare-mcp"))
+
+    def test_variants_run_after_the_first_install(self):
+        self.assertLess(runner.ORDER.index("npm-global"), runner.ORDER.index("channel-variant"))
+
+    def test_runtime_state_runs_last(self):
+        """The processes must still be alive when the second scan happens."""
+        self.assertEqual(runner.ORDER[-1], "runtime-state")
+
+    def test_ordering_is_stable_within_a_family(self):
+        entries = runner.ordered(self.manifest.for_platform("linux"))
+        npm = [e.id for e in entries if e.family == "npm-global"]
+        self.assertEqual(npm, sorted(npm))
+
+
+class Execution(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = manifest_module.load()
+
+    def test_a_dry_run_touches_no_guest_and_records_everything(self):
+        driver = DryDriver()
+        actual = runner.run(driver, self.manifest, platform="linux", image="dry", collector="dry")
+        self.assertEqual(actual["applicable"], 105)
+        self.assertEqual(actual["applicable"],
+                         actual["installed"] + actual["unavailable"] + actual["failed"])
+        self.assertTrue(driver.commands)
+
+    def test_a_pending_family_is_unavailable_with_a_reason(self):
+        """A family that silently no-opped would shrink the denominator."""
+        driver = DryDriver()
+        actual = runner.run(driver, self.manifest, platform="linux", image="dry", collector="dry")
+        rows = {row["id"]: row for row in actual["entries"]}
+        pending = [row for row in rows.values()
+                   if row["status"] == "unavailable" and "pending" in row.get("reason", "")]
+        self.assertTrue(pending)
+        self.assertTrue(all(row.get("reason") for row in pending))
+
+    def test_a_broken_recipe_fails_one_entry_rather_than_the_run(self):
+        def explode(driver, entry, platform):
+            raise RuntimeError("vendor changed the flags again")
+
+        actual = runner.run(DryDriver(), self.manifest, platform="linux",
+                            recipes={**REGISTRY, "npm-global": explode},
+                            image="dry", collector="dry")
+        failed = [row for row in actual["entries"] if row["status"] == "failed"]
+        self.assertTrue(failed)
+        self.assertIn("vendor changed the flags", failed[0]["reason"])
+        self.assertEqual(actual["applicable"], 105)
+
+    def test_an_unpinned_install_is_refused(self):
+        """An unpinned version makes the version field unscoreable."""
+        entry = self.manifest.by_id("T-CLI-01")
+        unpinned = type(entry)(**{**entry.__dict__,
+                                  "install": {**entry.install, "version": None}})
+        outcome = REGISTRY["npm-global"](DryDriver(), unpinned, "linux")
+        self.assertEqual(outcome.status, runner.FAILED)
+        self.assertIn("unpinned", outcome.reason)
+
+    def test_a_failing_command_is_a_failed_entry(self):
+        driver = DryDriver(failures={"npm": 1})
+        outcome = REGISTRY["npm-global"](driver, self.manifest.by_id("T-CLI-01"), "linux")
+        self.assertEqual(outcome.status, runner.FAILED)
+
+
+class Registry(unittest.TestCase):
+    def test_built_and_pending_together_cover_the_fourteen_families(self):
+        self.assertEqual(set(BUILT) | set(PENDING), set(runner.ORDER))
+
+    def test_nothing_is_both_built_and_pending(self):
+        self.assertEqual(set(BUILT) & set(PENDING), set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Discovery/tests/test_score.py
+++ b/Discovery/tests/test_score.py
@@ -1,0 +1,139 @@
+"""The scorer, and proof that it moves when something is actually wrong.
+
+A scorer that has only ever seen a perfect run is a scorer nobody has tested.
+Each fault below is one of the conditions the gate exists to catch, injected
+deliberately, with the score asserted to respond.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+from . import manifest as manifest_module
+from .scoring import schema, snapshot
+from .scoring.score import score
+from .tools import synthesize
+
+RECORDED = os.path.join(os.path.dirname(os.path.abspath(__file__)), "recorded", "synthetic-linux")
+
+
+def run_and_score(*faults, platform="linux", **plan):
+    """Both halves, because some properties are about what the runner skipped."""
+    directory = tempfile.mkdtemp()
+    synthesize.build(directory, plan=synthesize.Plan(platform=platform, faults=tuple(faults), **plan))
+    run = snapshot.load(directory)
+    return run, score(run, manifest_module.load(), platform=platform)
+
+
+def scored(*faults, platform="linux", **plan):
+    return run_and_score(*faults, platform=platform, **plan)[1]
+
+
+class RecordedRun(unittest.TestCase):
+    """The checked-in run is the baseline every scoring change is replayed against."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.score = score(snapshot.load(RECORDED), manifest_module.load())
+
+    def test_a_correct_collector_scores_perfectly(self):
+        self.assertEqual(self.score.totals.recall, 1.0)
+        self.assertEqual(self.score.totals.precision, 1.0)
+        self.assertEqual(self.score.totals.dup, 0)
+
+    def test_the_gate_passes(self):
+        self.assertTrue(schema.gate(self.score).passed)
+
+    def test_recall_is_reported_per_category(self):
+        """Never pooled: the denominators differ, and an average hides which one moved."""
+        self.assertGreater(len(self.score.by_category), 1)
+
+    def test_every_verdict_is_keyed_by_manifest_id(self):
+        ids = {entry.id for entry in manifest_module.load()}
+        for verdict in self.score.verdicts:
+            if verdict.outcome != "fp":
+                self.assertIn(verdict.entry_id, ids)
+
+
+class Faults(unittest.TestCase):
+    def test_a_missing_asset_is_a_false_negative(self):
+        result = scored("miss")
+        self.assertGreaterEqual(result.totals.fn, 1)
+        self.assertLess(result.totals.recall, 1.0)
+
+    def test_an_invented_asset_is_a_false_positive(self):
+        result = scored("invent")
+        self.assertGreaterEqual(result.totals.fp, 1)
+        self.assertLess(result.totals.precision, 1.0)
+
+    def test_a_second_asset_for_one_install_is_a_duplicate(self):
+        result = scored("duplicate")
+        self.assertGreaterEqual(result.totals.dup, 1)
+        self.assertFalse(schema.gate(result).passed)
+
+    def test_a_leaked_canary_fails_the_run_outright(self):
+        result = scored("leak")
+        self.assertGreaterEqual(result.canaries.leaked, 1)
+        gate = schema.gate(result)
+        self.assertFalse(gate.passed)
+        self.assertTrue(any("canary" in reason for reason in gate.reasons))
+
+    def test_a_dirty_baseline_fails_before_the_score_matters(self):
+        result = scored("dirty-baseline")
+        self.assertFalse(result.baseline_clean)
+        self.assertFalse(schema.gate(result).passed)
+
+    def test_a_wrong_field_lowers_that_field_and_not_recall(self):
+        """A tool found with the wrong facts is still found."""
+        result = scored("wrong-field")
+        self.assertEqual(result.totals.recall, 1.0)
+        self.assertLess(result.fields["version"], 1.0)
+
+
+class Denominators(unittest.TestCase):
+    def test_an_unavailable_entry_is_not_a_miss(self):
+        """The vendor's choice is not the collector's blind spot."""
+        clean = scored()
+        result = scored(unavailable=("T-CLI-01",))
+        self.assertEqual(result.totals.fn, 0)
+        self.assertEqual(clean.totals.tp - result.totals.tp,
+                         result.manifest_counts["unavailable"])
+
+    def test_a_variant_leaves_with_the_tool_it_duplicates(self):
+        """A second channel of a tool nobody installed was not installed either."""
+        run, _ = run_and_score(unavailable=("T-CLI-01",))
+        dropped = {o.id for o in run.outcomes if o.status == "unavailable"}
+        self.assertIn("T-CLI-01", dropped)
+        self.assertGreater(len(dropped), 1, "its variants and assertions must leave with it")
+
+    def test_a_failed_entry_leaves_the_denominator_but_is_reported(self):
+        result = scored(failed=("T-CLI-02",))
+        self.assertEqual(result.totals.fn, 0)
+        self.assertEqual(result.manifest_counts["failed"], 1)
+
+
+class Gate(unittest.TestCase):
+    def test_recall_below_the_previous_accepted_run_fails(self):
+        previous = schema.to_dict(score(snapshot.load(RECORDED), manifest_module.load()))
+        regressed = scored("miss")
+        gate = schema.gate(regressed, previous)
+        self.assertFalse(gate.passed)
+        self.assertTrue(any("recall fell" in reason for reason in gate.reasons))
+
+    def test_a_run_is_not_compared_against_another_os(self):
+        """Denominators differ per OS, so a cross-OS comparison is meaningless."""
+        previous = schema.to_dict(scored(platform="mac"))
+        previous["run"]["os"] = "mac"
+        gate = schema.gate(scored("miss"), previous)
+        self.assertFalse(any("recall fell" in reason for reason in gate.reasons))
+
+    def test_score_json_round_trips(self):
+        document = json.loads(schema.to_json(score(snapshot.load(RECORDED), manifest_module.load())))
+        self.assertEqual(document["schema_version"], schema.SCHEMA_VERSION)
+        self.assertIn("totals", document)
+        self.assertIn("canaries", document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Discovery/tests/test_snapshot.py
+++ b/Discovery/tests/test_snapshot.py
@@ -1,0 +1,83 @@
+"""A run is read from files, so the file boundary is asserted like a contract."""
+
+import json
+import os
+import tempfile
+import unittest
+
+from .scoring import snapshot
+from .tools import synthesize
+
+
+class RunLoading(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.directory = tempfile.mkdtemp()
+        synthesize.build(cls.directory, plan=synthesize.Plan(platform="linux"))
+
+    def test_a_run_round_trips_from_disk(self):
+        run = snapshot.load(self.directory)
+        self.assertEqual(run.os, "linux")
+        self.assertEqual(len(run.outcomes), 105)
+        self.assertEqual(len(run.canaries), 6)
+
+    def test_a_missing_file_is_an_error_rather_than_an_empty_run(self):
+        """Scoring nothing and scoring a run that found nothing are different claims."""
+        empty = tempfile.mkdtemp()
+        with self.assertRaises(snapshot.RunError):
+            snapshot.load(empty)
+
+    def test_malformed_json_names_the_file(self):
+        broken = tempfile.mkdtemp()
+        for name in (snapshot.BEFORE, snapshot.AFTER, snapshot.ACTUAL):
+            with open(os.path.join(broken, name), "w", encoding="utf-8") as handle:
+                handle.write("{not json")
+        with self.assertRaises(snapshot.RunError) as raised:
+            snapshot.load(broken)
+        self.assertIn(snapshot.BEFORE, str(raised.exception))
+
+    def test_an_unknown_status_is_refused(self):
+        """Three statuses, three meanings. A fourth would be scored as nothing."""
+        directory = tempfile.mkdtemp()
+        synthesize.build(directory, plan=synthesize.Plan(platform="linux"))
+        path = os.path.join(directory, snapshot.ACTUAL)
+        with open(path, encoding="utf-8") as handle:
+            document = json.load(handle)
+        document["entries"][0]["status"] = "probably"
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(document, handle)
+        with self.assertRaises(snapshot.RunError):
+            snapshot.load(directory)
+
+
+class Delta(unittest.TestCase):
+    def test_only_what_installation_caused_is_scored(self):
+        """Baseline noise present in both scans is not the manifest's invention."""
+        directory = tempfile.mkdtemp()
+        synthesize.build(directory, plan=synthesize.Plan(platform="linux", faults=("dirty-baseline",)))
+        run = snapshot.load(directory)
+
+        self.assertFalse(snapshot.baseline_is_clean(run.before))
+        carried = {a.asset_id for a in run.before.assets}
+        self.assertTrue(carried)
+        self.assertFalse(carried & {a.asset_id for a in snapshot.added(run)})
+
+    def test_a_clean_baseline_has_no_assets(self):
+        run = snapshot.load(_fixture())
+        self.assertTrue(snapshot.baseline_is_clean(run.before))
+
+
+class Outcomes(unittest.TestCase):
+    def test_only_installed_is_scoreable(self):
+        """A vendor that does not ship here is not a collector blind spot."""
+        self.assertTrue(snapshot.Outcome("X", "installed").is_scoreable)
+        self.assertFalse(snapshot.Outcome("X", "unavailable").is_scoreable)
+        self.assertFalse(snapshot.Outcome("X", "failed").is_scoreable)
+
+
+def _fixture():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "recorded", "synthetic-linux")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add bootstrap and canary coverage
- add matching, reporting, runner, scoring, and snapshot tests

## Validation
- Python AST parse
- git diff --check

## Dependency note
These tests import other currently untracked discovery and harness modules and will become runnable when those modules are committed separately.