### PR TITLE
test(discovery): add scoring harness

### DIFF
--- a/Discovery/tests/scoring/__init__.py
+++ b/Discovery/tests/scoring/__init__.py
@@ -1,0 +1,6 @@
+"""The scoring engine: a pure function from three JSON files to a verdict.
+
+No VM, no network, no clock. That is what lets a failed run be re-scored
+without re-running it, and a scoring bug be fixed and replayed against every
+run ever recorded.
+"""

--- a/Discovery/tests/scoring/canary.py
+++ b/Discovery/tests/scoring/canary.py
@@ -1,0 +1,86 @@
+"""Did a planted credential survive into the output.
+
+Six canaries are planted across M-SP-03..05, S-16 and AG-12. The check is
+deliberately crude - a substring search of the serialized snapshot - because
+the interesting leak is the one that lands in a field nobody thought to
+inspect. Walking the object graph would only find the fields we remembered.
+
+A hit fails the run outright, regardless of every other score. There is no
+recall number worth a leaked credential.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Tuple
+
+#: A canary value shorter than this would match unrelated text by accident and
+#: report a leak that is not one.
+MIN_LENGTH = 12
+
+
+class CanaryError(ValueError):
+    """A canary set that would make the check meaningless."""
+
+
+@dataclass(frozen=True)
+class Leak:
+    name: str
+    where: str
+
+
+@dataclass(frozen=True)
+class CanaryReport:
+    planted: int = 0
+    leaks: Tuple[Leak, ...] = ()
+    undeclared: Tuple[str, ...] = ()
+    unplanted: Tuple[str, ...] = ()
+
+    @property
+    def leaked(self) -> int:
+        return len(self.leaks)
+
+    @property
+    def clean(self) -> bool:
+        return not self.leaks
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "planted": self.planted,
+            "leaked": self.leaked,
+            "leaks": [{"name": leak.name, "where": leak.where} for leak in self.leaks],
+            "undeclared": list(self.undeclared),
+            "unplanted": list(self.unplanted),
+        }
+
+
+def check(values: Mapping[str, str], documents: Mapping[str, str],
+          declared: Iterable[str] = ()) -> CanaryReport:
+    """Search each document for each planted value.
+
+    ``documents`` is a mapping of label to serialized text so a leak can be
+    reported against the file it appeared in rather than just asserted.
+    """
+    declared_names = tuple(declared)
+    planted = {name: value for name, value in values.items() if value}
+
+    for name, value in planted.items():
+        if len(value) < MIN_LENGTH:
+            raise CanaryError(
+                f"canary {name!r} is {len(value)} characters; anything under "
+                f"{MIN_LENGTH} will collide with ordinary text and report a leak that is not one"
+            )
+
+    leaks = tuple(
+        Leak(name=name, where=label)
+        for label, text in documents.items()
+        for name, value in sorted(planted.items())
+        if value in text
+    )
+
+    undeclared = tuple(sorted(set(planted) - set(declared_names))) if declared_names else ()
+    unplanted = tuple(sorted(set(declared_names) - set(planted))) if declared_names else ()
+    return CanaryReport(planted=len(planted), leaks=leaks, undeclared=undeclared, unplanted=unplanted)
+
+
+__all__ = ["CanaryError", "CanaryReport", "Leak", "MIN_LENGTH", "check"]

--- a/Discovery/tests/scoring/match.py
+++ b/Discovery/tests/scoring/match.py
@@ -1,0 +1,282 @@
+"""Manifest entry to reported asset, by entry shape.
+
+The shape - not the category - decides how a row is matched, because the four
+shapes are four different claims. An installed tool claims a catalog identity;
+a declared server claims a launch identity; a created file claims a path; a
+state claims an asset plus a liveness. Matching each by the wrong key is how a
+harness reports confident nonsense.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from adr_discovery.contracts.records import Asset
+
+from ..manifest import Entry
+
+#: Environment references that appear in manifest paths but never in a
+#: collector's realpath output.
+_HOME_PREFIXES = ("~", "%USERPROFILE%", "$HOME")
+
+
+@dataclass(frozen=True)
+class Match:
+    """One entry and every asset that answered to it.
+
+    ``assets`` is a list rather than an optional because the count is the
+    finding: zero is a blind spot, one is success, and two or more is the
+    duplicate that inflates a fleet inventory.
+    """
+
+    entry_id: str
+    assets: Tuple[str, ...] = ()
+    key: str = ""
+    how: str = ""
+
+
+@dataclass(frozen=True)
+class Matching:
+    """The full join, in both directions."""
+
+    matches: Tuple[Match, ...] = ()
+    unmatched_assets: Tuple[str, ...] = ()
+
+    def for_entry(self, entry_id: str) -> Optional[Match]:
+        for match in self.matches:
+            if match.entry_id == entry_id:
+                return match
+        return None
+
+
+def normalize_path(path: Optional[str], home: str = "/root") -> str:
+    """A manifest path and a collector path, made comparable.
+
+    Manifests are written the way a person writes a path; collectors report
+    what the filesystem resolved to. Comparing them literally produces false
+    negatives that look like collector bugs.
+    """
+    if not path:
+        return ""
+    text = path.strip().replace("\\", "/")
+    for prefix in _HOME_PREFIXES:
+        if text == prefix:
+            text = home
+            break
+        if text.startswith(prefix + "/"):
+            text = home.rstrip("/") + "/" + text[len(prefix) + 1:]
+            break
+    text = posixpath.normpath(text)
+    return text.rstrip("/").lower() or "/"
+
+
+def launch_identity(command: Optional[str], args: Optional[Sequence[str]], home: str = "/root") -> str:
+    """A declared server's identity: what would actually be executed.
+
+    Normalized because ``docker run x`` and ``/usr/bin/docker   run  x`` are
+    the same server declared by two people, and a scorer that disagrees is
+    measuring formatting.
+    """
+    binary = posixpath.basename(normalize_path(command, home)) if command else ""
+    parts = [binary]
+    for arg in args or ():
+        token = str(arg).strip()
+        if not token:
+            continue
+        if _looks_like_path(token):
+            token = normalize_path(token, home)
+        parts.append(token.lower())
+    return " ".join(p for p in parts if p)
+
+
+def _looks_like_path(token: str) -> bool:
+    return token.startswith(_HOME_PREFIXES) or "/" in token or "\\" in token
+
+
+def match(entries: Iterable[Entry], assets: Sequence[Asset], *, outcomes: Optional[Mapping[str, Any]] = None,
+          platform: str = "linux", home: str = "/root") -> Matching:
+    """Join installed entries to reported assets.
+
+    Keys come from what the runner recorded first and the manifest second: the
+    manifest is intent, and an entry installed somewhere other than where it
+    was declared is still installed.
+
+    Rows that share a key are the normal case, not an edge case - nineteen
+    skill rows write into a handful of settings files. Assets at a shared key
+    are therefore distributed one per row rather than handed wholesale to
+    whichever row sorts first, and only a genuine surplus is reported as a
+    duplicate. Without that, DUP would measure how the manifest is written
+    rather than what the collector did.
+    """
+    outcomes = outcomes or {}
+    index = _Index(assets, home=home)
+    ordered = sorted(entries, key=lambda e: e.id)
+
+    found: Dict[str, Match] = {}
+    groups: Dict[str, List[Tuple[Entry, str]]] = {}
+
+    attachments: List[Entry] = []
+    for entry in ordered:
+        if _attaches_to(entry):
+            attachments.append(entry)
+            continue
+        if entry.variant_of:
+            # A second install of a tool already claimed by its base row.
+            # Letting it claim too would manufacture the duplicate it detects.
+            found[entry.id] = Match(entry.id, (), entry.variant_of, "variant")
+            continue
+        key, how = _key_for(entry, outcomes.get(entry.id), platform=platform, home=home)
+        if not key:
+            found[entry.id] = Match(entry.id, (), key, how)
+            continue
+        groups.setdefault(f"{how}\x00{key}", []).append((entry, how))
+
+    claimed: Dict[str, str] = {}
+    for bucket, members in sorted(groups.items()):
+        how, key = bucket.split("\x00", 1)
+        available = [a for a in index.lookup(key, how) if a not in claimed]
+        for position, (entry, entry_how) in enumerate(members):
+            if position >= len(available):
+                mine: List[str] = []
+            elif position == len(members) - 1:
+                # The last row absorbs any surplus, so an extra asset at a
+                # shared key is reported as a duplicate instead of vanishing.
+                mine = available[position:]
+            else:
+                mine = [available[position]]
+            for asset_id in mine:
+                claimed[asset_id] = entry.id
+            found[entry.id] = Match(entry.id, tuple(mine), key, entry_how)
+
+    for entry in attachments:
+        # Resolved after the main pass and deliberately without claiming: the
+        # asset belongs to the row that installed the tool, and an assertion
+        # about it is not a second sighting of it.
+        target = str(_attaches_to(entry)).strip().lower()
+        found[entry.id] = Match(entry.id, tuple(index.lookup(target, "catalog_id")), target, "attached")
+
+    matches = tuple(found[entry.id] for entry in ordered)
+    leftover = tuple(a.asset_id for a in assets if a.asset_id not in claimed)
+    return Matching(matches=matches, unmatched_assets=leftover)
+
+
+def _attaches_to(entry: Entry) -> Optional[str]:
+    """The tool an ``assert_only`` state row makes a claim about, if any."""
+    if entry.shape != "state":
+        return None
+    block = entry.state
+    return block.get("tool") if block.get("assert_only") else None
+
+
+def identity_of(entry: Entry, outcome: Any = None, *, platform: str = "linux",
+                home: str = "/root") -> str:
+    """What a correct collector would report as this entry's identity.
+
+    Public because the synthesizer needs the same answer: a fixture built from
+    a different notion of identity than the scorer uses tests the fixture.
+    """
+    recorded_id = getattr(outcome, "catalog_id", None)
+    recorded_path = getattr(outcome, "path", None)
+    shape = entry.shape
+
+    if shape == "install":
+        named = recorded_id or entry.catalog_id or entry.install.get("source") or entry.install.get("binary")
+        if named:
+            return str(named).strip().lower()
+        return normalize_path(recorded_path or entry.install.get("path"), home) or entry.id.lower()
+    if shape == "declare":
+        command = entry.declare.get("command")
+        if command:
+            return launch_identity(command, entry.declare.get("args"), home)
+        # A remote server launches nothing; it is identified by where it points.
+        remote = entry.declare.get("url") or entry.declare.get("server_name")
+        return str(remote or "").strip().lower()
+    if shape == "create":
+        return normalize_path(recorded_path or entry.path_for(platform), home)
+    return _state_key(entry, home=home)
+
+
+def _key_for(entry: Entry, outcome: Any, *, platform: str, home: str) -> Tuple[str, str]:
+    """The single value this entry is matched on, and the rule that chose it."""
+    identity = identity_of(entry, outcome, platform=platform, home=home)
+    shape = entry.shape
+
+    if shape == "install":
+        if getattr(outcome, "catalog_id", None) or entry.catalog_id:
+            return identity, "catalog_id"
+        return identity, "install_path" if identity.startswith("/") else "identity"
+    if shape == "declare":
+        site = normalize_path(getattr(outcome, "path", None) or entry.path_for(platform), home)
+        scope = str(entry.declare.get("scope") or "").lower()
+        return "|".join(p for p in (identity, site, scope) if p), "launch_identity"
+    if shape == "create":
+        return identity, "path"
+    return identity, "identity" if not identity.startswith("/") else "path"
+
+
+def _state_key(entry: Entry, *, home: str) -> str:
+    """A state attaches to something: the command it runs, or the file it is in."""
+    block = entry.state
+    command = block.get("command") or block.get("launch")
+    if command:
+        return launch_identity(_program(command), _arguments(command), home)
+    return normalize_path(block.get("path"), home)
+
+
+def _program(command: str) -> str:
+    parts = re.split(r"\s+", str(command).strip())
+    return parts[0] if parts else ""
+
+
+def _arguments(command: str) -> List[str]:
+    parts = re.split(r"\s+", str(command).strip())
+    return parts[1:]
+
+
+class _Index:
+    """Assets, keyed every way an entry might ask for them."""
+
+    def __init__(self, assets: Sequence[Asset], *, home: str) -> None:
+        self.by_catalog: Dict[str, List[str]] = {}
+        self.by_path: Dict[str, List[str]] = {}
+        self.by_identity: Dict[str, List[str]] = {}
+        self.assets = {a.asset_id: a for a in assets}
+        for asset in assets:
+            if asset.catalog_id:
+                self.by_catalog.setdefault(asset.catalog_id, []).append(asset.asset_id)
+            for path in {normalize_path(p, home) for p in (asset.install_path, asset.install_root)}:
+                if path:
+                    self.by_path.setdefault(path, []).append(asset.asset_id)
+            identity = (asset.identity or "").strip().lower()
+            if identity:
+                self.by_identity.setdefault(identity, []).append(asset.asset_id)
+
+    def lookup(self, key: str, how: str) -> List[str]:
+        if not key:
+            return []
+        if how == "catalog_id":
+            return list(self.by_catalog.get(key, ()))
+        if how in ("install_path", "path"):
+            return list(self.by_path.get(key, ()))
+        if how == "identity":
+            return list(self.by_identity.get(key, ())) or list(self.by_path.get(key, ()))
+        identity, _, rest = key.partition("|")
+        site = rest.partition("|")[0]
+        by_identity = list(self.by_identity.get(identity, ()))
+        if site:
+            at_site = set(self.by_path.get(site, ()))
+            narrowed = [a for a in by_identity if a in at_site]
+            if narrowed:
+                return narrowed
+            if by_identity:
+                return by_identity
+            # A server the collector identified differently is still the same
+            # server if it sits in the config file the manifest declared it in.
+            return list(self.by_path.get(site, ()))
+        return by_identity
+
+
+__all__ = ["Match", "Matching", "identity_of", "launch_identity", "match", "normalize_path"]

--- a/Discovery/tests/scoring/schema.py
+++ b/Discovery/tests/scoring/schema.py
@@ -1,0 +1,88 @@
+"""score.json - the shape, and the gate that reads it.
+
+One file for machines and trends. Every miss and invention is keyed by
+manifest id, so a regression is reported as ``M-SITE-08 went from TP to FN``
+rather than as a number that moved.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from .score import Score
+
+SCHEMA_VERSION = 1
+
+#: Anything here fails a run outright, whatever the recall number says.
+ABSOLUTE = ("canary_leaked", "baseline_dirty", "unexplained_errors", "duplicates", "review_queue")
+
+
+@dataclass(frozen=True)
+class Gate:
+    passed: bool
+    reasons: Tuple[str, ...] = ()
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"passed": self.passed, "reasons": list(self.reasons)}
+
+
+def to_dict(score: Score) -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run": {"id": score.run_id, "os": score.os, "image": score.image,
+                "collector": score.collector},
+        "baseline": {"asset_count": score.baseline_assets, "clean": score.baseline_clean},
+        "manifest": score.manifest_counts,
+        "totals": score.totals.as_dict(),
+        "by_category": {name: counts.as_dict() for name, counts in score.by_category.items()},
+        "fields": score.fields,
+        "canaries": score.canaries.as_dict(),
+        "errors": score.errors,
+        "review_queue": {"ok": score.review_queue_ok},
+        "misses": [{"id": v.entry_id, "category": v.category, "reason": v.detail}
+                   for v in score.misses],
+        "inventions": [{"id": v.entry_id, "category": v.category, "detail": v.detail}
+                       for v in score.inventions],
+        "duplicates": [{"id": v.entry_id, "category": v.category, "assets": list(v.assets)}
+                       for v in score.duplicates],
+    }
+
+
+def to_json(score: Score, indent: Optional[int] = 2) -> str:
+    return json.dumps(to_dict(score), indent=indent, sort_keys=True)
+
+
+def gate(score: Score, previous: Optional[Dict[str, Any]] = None) -> Gate:
+    """Pass or fail, with every reason rather than the first one.
+
+    Recall is compared against the previous accepted run for the same OS
+    rather than an absolute threshold: real endpoints are not perfectly
+    reproducible, and a fixed number would either be gamed or ignored.
+    """
+    reasons: List[str] = []
+
+    if not score.canaries.clean:
+        leaked = ", ".join(sorted(leak.name for leak in score.canaries.leaks))
+        reasons.append(f"canary leaked: {leaked}")
+    if not score.baseline_clean:
+        reasons.append(f"baseline reported {score.baseline_assets} assets before installation")
+    if score.errors.get("unexplained"):
+        reasons.append(f"{score.errors['unexplained']} unexplained errors")
+    if score.totals.dup:
+        reasons.append(f"{score.totals.dup} duplicate assets")
+    if score.review_queue_ok is False:
+        reasons.append("review queue did not contain the in-house wrapper")
+
+    if previous:
+        before = (previous.get("totals") or {}).get("recall")
+        now = score.totals.recall
+        same_os = previous.get("run", {}).get("os", score.os) == score.os
+        if same_os and before is not None and now is not None and now < before:
+            reasons.append(f"recall fell from {before} to {now}")
+
+    return Gate(passed=not reasons, reasons=tuple(reasons))
+
+
+__all__ = ["ABSOLUTE", "Gate", "SCHEMA_VERSION", "gate", "to_dict", "to_json"]

--- a/Discovery/tests/scoring/score.py
+++ b/Discovery/tests/scoring/score.py
@@ -1,0 +1,334 @@
+"""TP, FP, FN, DUP - and the reasons they are four numbers and not two.
+
+Recall and precision are computed per category and per OS and never pooled,
+because the denominators differ by OS: an entry that does not apply to Linux
+is not a Linux miss, and averaging the three hides which platform regressed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from adr_discovery.contracts.records import Asset
+
+from ..manifest import Entry, Manifest
+from . import canary as canary_module
+from .match import Matching, match
+from .snapshot import Run, added, baseline_is_clean, serialized
+
+TP, FP, FN, DUP = "tp", "fp", "fn", "dup"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """One entry's outcome, keyed by manifest id.
+
+    Keyed by id so a regression reads ``M-SITE-08 went from TP to FN`` rather
+    than "MCP recall dropped", which nobody can act on.
+    """
+
+    entry_id: str
+    category: str
+    outcome: str
+    assets: Tuple[str, ...] = ()
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class Counts:
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    dup: int = 0
+
+    @property
+    def recall(self) -> Optional[float]:
+        found = self.tp + self.fn
+        return round(self.tp / found, 4) if found else None
+
+    @property
+    def precision(self) -> Optional[float]:
+        claimed = self.tp + self.fp
+        return round(self.tp / claimed, 4) if claimed else None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"tp": self.tp, "fp": self.fp, "fn": self.fn, "dup": self.dup,
+                "recall": self.recall, "precision": self.precision}
+
+
+@dataclass(frozen=True)
+class Score:
+    run_id: str
+    os: str
+    image: str
+    collector: str
+    baseline_clean: bool
+    baseline_assets: int
+    manifest_counts: Dict[str, int] = field(default_factory=dict)
+    totals: Counts = field(default_factory=Counts)
+    by_category: Dict[str, Counts] = field(default_factory=dict)
+    fields: Dict[str, Optional[float]] = field(default_factory=dict)
+    verdicts: Tuple[Verdict, ...] = ()
+    canaries: canary_module.CanaryReport = field(default_factory=canary_module.CanaryReport)
+    errors: Dict[str, int] = field(default_factory=dict)
+    review_queue_ok: Optional[bool] = None
+
+    @property
+    def misses(self) -> Tuple[Verdict, ...]:
+        return tuple(v for v in self.verdicts if v.outcome == FN)
+
+    @property
+    def inventions(self) -> Tuple[Verdict, ...]:
+        return tuple(v for v in self.verdicts if v.outcome == FP)
+
+    @property
+    def duplicates(self) -> Tuple[Verdict, ...]:
+        return tuple(v for v in self.verdicts if v.outcome == DUP)
+
+
+def score(run: Run, manifest: Manifest, *, platform: Optional[str] = None,
+          home: str = "/root") -> Score:
+    """The whole measurement, as one pure call over already-loaded files."""
+    platform = platform or run.os
+    assets = added(run)
+    scoreable = _scoreable_entries(run, manifest)
+
+    outcomes = {o.id: o for o in run.installed}
+    matching = match(scoreable, assets, outcomes=outcomes, platform=platform, home=home)
+    verdicts = _verdicts(scoreable, matching, assets, manifest, platform=platform)
+
+    totals = _tally(verdicts)
+    by_category = {
+        category: _tally([v for v in verdicts if v.category == category])
+        for category in sorted({v.category for v in verdicts})
+    }
+
+    return Score(
+        run_id=run.run_id,
+        os=run.os,
+        image=run.image,
+        collector=run.collector,
+        baseline_clean=baseline_is_clean(run.before),
+        baseline_assets=len(run.before.assets),
+        manifest_counts=run.counts,
+        totals=totals,
+        by_category=by_category,
+        fields=_field_accuracy(scoreable, matching, assets, run),
+        verdicts=verdicts,
+        canaries=canary_module.check(
+            run.canaries,
+            {"after.json": serialized(run.after)},
+            declared=manifest.canary_names(),
+        ),
+        errors=_errors(run, manifest),
+        review_queue_ok=_review_queue(run, manifest),
+    )
+
+
+def _scoreable_entries(run: Run, manifest: Manifest) -> List[Entry]:
+    """Only entries the runner actually installed are scored.
+
+    An entry the vendor does not ship here, or one that failed outright, is
+    excluded from both numerator and denominator - being counted as a miss
+    would blame the collector for the harness.
+    """
+    scoreable: List[Entry] = []
+    for recorded in run.installed:
+        try:
+            entry = manifest.by_id(recorded.id)
+        except KeyError:
+            continue
+        if not entry.must_not_appear:
+            scoreable.append(entry)
+    return scoreable
+
+
+def _verdicts(entries: Sequence[Entry], matching: Matching, assets: Sequence[Asset],
+              manifest: Manifest, *, platform: str) -> Tuple[Verdict, ...]:
+    verdicts: List[Verdict] = []
+
+    for entry in entries:
+        if entry.variant_of:
+            verdicts.append(_variant_verdict(entry, matching))
+            continue
+        found = matching.for_entry(entry.id)
+        count = len(found.assets) if found else 0
+        if count == 1:
+            outcome, detail = TP, ""
+        elif count == 0:
+            where = f"{found.how} {found.key}".strip() if found else "entry"
+            outcome, detail = FN, f"no asset matched {where}"
+        else:
+            outcome, detail = DUP, f"{count} assets matched one entry"
+        verdicts.append(Verdict(entry.id, entry.category, outcome,
+                                tuple(found.assets) if found else (), detail))
+
+    by_id = {a.asset_id: a for a in assets}
+    for asset_id in matching.unmatched_assets:
+        asset = by_id.get(asset_id)
+        verdicts.append(Verdict(
+            entry_id=asset_id,
+            category=asset.kind.value if asset else "unknown",
+            outcome=FP,
+            assets=(asset_id,),
+            detail=f"{asset.name} at {asset.install_path}" if asset else "",
+        ))
+    return tuple(verdicts)
+
+
+def _variant_verdict(entry: Entry, matching: Matching) -> Verdict:
+    """A channel variant is scored on what its base tool reported.
+
+    Two installs of one tool must yield one asset. That is the whole point of
+    the eight T-CHAN rows: they provoke the duplicate that inflates a fleet
+    inventory, and they pass only when the collector refuses to be provoked.
+    """
+    base = matching.for_entry(entry.variant_of)
+    count = len(base.assets) if base else 0
+    if count == 1:
+        return Verdict(entry.id, entry.category, TP, tuple(base.assets), f"deduplicated with {entry.variant_of}")
+    if count == 0:
+        return Verdict(entry.id, entry.category, FN, (), f"base {entry.variant_of} reported no asset")
+    return Verdict(entry.id, entry.category, DUP, tuple(base.assets),
+                   f"{count} assets for {entry.variant_of} installed twice")
+
+
+def _tally(verdicts: Iterable[Verdict]) -> Counts:
+    counts = {TP: 0, FP: 0, FN: 0, DUP: 0}
+    for verdict in verdicts:
+        counts[verdict.outcome] = counts.get(verdict.outcome, 0) + 1
+    return Counts(tp=counts[TP], fp=counts[FP], fn=counts[FN], dup=counts[DUP])
+
+
+def _field_accuracy(entries: Sequence[Entry], matching: Matching, assets: Sequence[Asset],
+                    run: Run) -> Dict[str, Optional[float]]:
+    """Per field, over true positives only.
+
+    Reported per field rather than blended: a collector that always gets
+    version right and always gets config_scope wrong has a specific bug, and
+    an average hides exactly that.
+    """
+    by_id = {a.asset_id: a for a in assets}
+    right: Dict[str, int] = {}
+    total: Dict[str, int] = {}
+
+    for entry in entries:
+        found = matching.for_entry(entry.id)
+        if not found or len(found.assets) != 1:
+            continue
+        asset = by_id.get(found.assets[0])
+        if asset is None:
+            continue
+        recorded = run.outcome(entry.id)
+        for name, expected in _expectations(entry).items():
+            actual = _observed(asset, name, recorded)
+            if actual is None:
+                continue
+            total[name] = total.get(name, 0) + 1
+            if _same(expected, actual):
+                right[name] = right.get(name, 0) + 1
+
+    return {name: round(right.get(name, 0) / count, 4) if count else None
+            for name, count in sorted(total.items())}
+
+
+def _expectations(entry: Entry) -> Dict[str, Any]:
+    """Everything this row asserts about the asset it produces.
+
+    A pinned version counts even when ``expect`` does not repeat it: pinning
+    exists precisely so that version stops being a guess and becomes a check,
+    and a pin nobody verifies is a comment.
+    """
+    declared = dict(entry.expect)
+    pinned = entry.install.get("version")
+    if pinned and "version" not in declared:
+        declared["version"] = pinned
+    return declared
+
+
+def _observed(asset: Asset, name: str, recorded) -> Optional[Any]:
+    """Where a declared field is actually found on a reported asset."""
+    if name == "kind":
+        return asset.kind.value
+    if name == "liveness":
+        return asset.liveness.value
+    if name == "version":
+        return asset.version
+    if name == "install_method":
+        return asset.install_method
+    value = getattr(asset, name, None)
+    if value is None:
+        # Anything the collector records as a flag rather than a column:
+        # transport, config_scope, pinned, has_identity, risk_factor.
+        value = _from_evidence(asset, name)
+    return value
+
+
+def _from_evidence(asset: Asset, name: str) -> Optional[Any]:
+    """Fields the collector records as evidence rather than as columns."""
+    for flag in asset.flags:
+        if flag.startswith(f"{name}="):
+            return flag.split("=", 1)[1]
+    return None
+
+
+_TRUE = {"true", "1", "yes"}
+_FALSE = {"false", "0", "no"}
+
+
+def _norm(value: Any) -> str:
+    return str(value).strip().lower()
+
+
+def _same(expected: Any, actual: Any) -> bool:
+    """Compare a declared expectation with what the collector reported.
+
+    Booleans are compared by meaning rather than by truthiness. A collector
+    reports flags as text, and ``bool("false")`` is True - which silently
+    scored every ``pinned = false`` expectation as wrong.
+    """
+    if isinstance(expected, (list, tuple, set)):
+        return {_norm(v) for v in expected} <= {_norm(v) for v in (actual or ())}
+
+    left, right = _norm(expected), _norm(actual)
+    if left in _TRUE or left in _FALSE or right in _TRUE or right in _FALSE:
+        return (left in _TRUE) == (right in _TRUE)
+    return left == right
+
+
+def _errors(run: Run, manifest: Manifest) -> Dict[str, int]:
+    """Errors must be zero, or explained by something the manifest created.
+
+    N-09 plants a dangling symlink precisely so that one error is expected;
+    an unexplained error means the collector hit something nobody predicted.
+    """
+    coverage = run.after.coverage
+    denied = len(getattr(coverage, "denied", ()) or ())
+    unavailable = len(getattr(coverage, "unavailable", ()) or ())
+    count = denied + unavailable
+    explained = sum(1 for entry in manifest if entry.explains_error)
+    return {"count": count, "explained": min(count, explained),
+            "unexplained": max(0, count - explained)}
+
+
+def _review_queue(run: Run, manifest: Manifest) -> Optional[bool]:
+    """N-10 must be triaged, not asserted.
+
+    Being confidently wrong and being silent are different failures, so the
+    in-house wrapper is scored on its own: it belongs in the review queue and
+    must not appear as an asset.
+    """
+    wanted = [e for e in manifest if e.must_be_reviewed]
+    if not wanted:
+        return None
+    queued = " ".join(item.path for item in run.after.review_queue).lower()
+    names = " ".join(a.name.lower() for a in run.after.assets)
+    for entry in wanted:
+        token = (entry.name or entry.id).lower()
+        if token not in queued or token in names:
+            return False
+    return True
+
+
+__all__ = ["Counts", "DUP", "FN", "FP", "Score", "TP", "Verdict", "score"]

--- a/Discovery/tests/scoring/snapshot.py
+++ b/Discovery/tests/scoring/snapshot.py
@@ -1,0 +1,192 @@
+"""Reading a run off disk, and reducing it to the part worth scoring.
+
+Scoring works on the delta rather than the raw second scan. A golden image is
+never perfectly empty, and residual baseline noise present in both scans would
+otherwise be charged to the manifest as invention. What survives here is the
+set of assets that installation actually caused to appear.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+from adr_discovery.contracts.records import Asset
+from adr_discovery.contracts.snapshot import Snapshot
+from adr_discovery.reporter.delta import diff
+from adr_discovery.reporter.snapshot import from_dict
+
+BEFORE = "before.json"
+AFTER = "after.json"
+ACTUAL = "manifest.actual.json"
+CANARIES = "canaries.json"
+
+#: The two delta kinds that mean "this asset was not here before".
+#: ``reinstalled`` counts because the asset carries a new id: to an operator
+#: reading an inventory it is a new row, and scoring reads what they read.
+APPEARED = ("appeared", "reinstalled")
+
+#: The three statuses the runner may record. Only one of them is scoreable.
+STATUSES = ("installed", "unavailable", "failed")
+
+
+class RunError(ValueError):
+    """A run directory that cannot be scored, said plainly rather than crashed."""
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """What the runner recorded actually happened for one manifest id.
+
+    Scoring compares against this, never against the manifest: the manifest is
+    intent, and an entry that did not install is not a blind spot.
+    """
+
+    id: str
+    status: str
+    catalog_id: Optional[str] = None
+    version: Optional[str] = None
+    path: Optional[str] = None
+    method: Optional[str] = None
+    reason: Optional[str] = None
+
+    @property
+    def is_scoreable(self) -> bool:
+        """``unavailable`` and ``failed`` both leave the denominator.
+
+        The distinction is kept for the report rather than the arithmetic:
+        one is the vendor's choice, the other is a broken harness, and a
+        denominator that shrinks quietly flatters every recall number after it.
+        """
+        return self.status == "installed"
+
+
+@dataclass(frozen=True)
+class Run:
+    """One scored run: two scans, what the runner did, and the planted canaries."""
+
+    os: str
+    image: str
+    before: Snapshot
+    after: Snapshot
+    outcomes: Tuple[Outcome, ...] = ()
+    canaries: Dict[str, str] = field(default_factory=dict)
+    collector: str = "unknown"
+    run_id: str = "unnamed"
+
+    def outcome(self, entry_id: str) -> Optional[Outcome]:
+        for recorded in self.outcomes:
+            if recorded.id == entry_id:
+                return recorded
+        return None
+
+    @property
+    def installed(self) -> Tuple[Outcome, ...]:
+        return tuple(o for o in self.outcomes if o.is_scoreable)
+
+    @property
+    def counts(self) -> Dict[str, int]:
+        tally = {status: 0 for status in STATUSES}
+        for recorded in self.outcomes:
+            tally[recorded.status] = tally.get(recorded.status, 0) + 1
+        tally["applicable"] = len(self.outcomes)
+        return tally
+
+
+def added(run: "Run") -> Tuple[Asset, ...]:
+    """The assets the second scan reports that the first one did not.
+
+    Derived through the shipped delta rather than a set difference here, so
+    the harness scores the same notion of "new" that the product reports.
+    """
+    delta = diff(run.before, run.after)
+    fresh = {c.asset_id for c in delta.changes if c.kind in APPEARED}
+    return tuple(a for a in run.after.assets if a.asset_id in fresh)
+
+
+def baseline_is_clean(before: Snapshot) -> bool:
+    """A baseline with assets in it has nothing to blame them on.
+
+    Asserted separately and before installation, because anything the golden
+    image reports is a false positive whose manifest row does not exist.
+    """
+    return not before.assets
+
+
+def load(directory: str) -> Run:
+    """Read a run directory. Missing files are an error, not an empty run."""
+    before = _snapshot(directory, BEFORE)
+    after = _snapshot(directory, AFTER)
+    actual = _json(os.path.join(directory, ACTUAL))
+    canaries = _optional_json(os.path.join(directory, CANARIES)) or {}
+
+    if not isinstance(actual.get("entries"), list):
+        raise RunError(f"{ACTUAL} has no entries list; nothing to score against")
+
+    outcomes = tuple(_outcome(row) for row in actual["entries"])
+    return Run(
+        os=actual.get("os", "unknown"),
+        image=actual.get("image", "unknown"),
+        before=before,
+        after=after,
+        outcomes=outcomes,
+        canaries={str(k): str(v) for k, v in canaries.items()},
+        collector=actual.get("collector", "unknown"),
+        run_id=actual.get("run_id", os.path.basename(directory.rstrip("/")) or "unnamed"),
+    )
+
+
+def _outcome(row: Dict[str, Any]) -> Outcome:
+    entry_id = row.get("id")
+    if not entry_id:
+        raise RunError("an outcome with no id cannot be joined to the manifest")
+    status = row.get("status")
+    if status not in STATUSES:
+        raise RunError(f"{entry_id}: status {status!r} is not one of {STATUSES}")
+    return Outcome(
+        id=entry_id,
+        status=status,
+        catalog_id=row.get("catalog_id"),
+        version=row.get("version"),
+        path=row.get("path"),
+        method=row.get("method"),
+        reason=row.get("reason"),
+    )
+
+
+def _snapshot(directory: str, name: str) -> Snapshot:
+    return from_dict(_json(os.path.join(directory, name)))
+
+
+def _json(path: str) -> Dict[str, Any]:
+    if not os.path.isfile(path):
+        raise RunError(f"{path} is missing; a run is scored from its files, not from a VM")
+    with open(path, encoding="utf-8") as handle:
+        try:
+            return json.load(handle)
+        except json.JSONDecodeError as broken:
+            raise RunError(f"{path} is not valid JSON: {broken}") from broken
+
+
+def _optional_json(path: str) -> Optional[Dict[str, Any]]:
+    return _json(path) if os.path.isfile(path) else None
+
+
+def serialized(snapshot: Snapshot) -> str:
+    """The snapshot as the collector would emit it.
+
+    The canary check searches this rather than walking the object graph: a
+    credential that leaks into a field nobody thought to inspect is exactly
+    the leak worth catching.
+    """
+    from adr_discovery.reporter.snapshot import to_json
+
+    return to_json(snapshot, indent=None)
+
+
+__all__ = [
+    "ACTUAL", "AFTER", "BEFORE", "CANARIES", "Outcome", "Run", "RunError",
+    "added", "baseline_is_clean", "load", "serialized",
+]


### PR DESCRIPTION
## Summary
- add matching and scoring logic
- add schema, canary, and snapshot support

## Validation
- syntax/data validation
- git diff --check

## Dependency note
This directory is part of the discovery test harness split across directory-specific PRs.