### PR TITLE
feat(discovery): add collector contracts

### DIFF
--- a/Discovery/adr_discovery/contracts/evidence.py
+++ b/Discovery/adr_discovery/contracts/evidence.py
@@ -1,0 +1,81 @@
+"""Evidence — why we believe a claim.
+
+Every verdict, observation and asset carries these. A claim with an empty
+evidence list is a bug, not a low-confidence answer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Sequence
+
+
+class Channel(str, Enum):
+    """Where a piece of evidence came from.
+
+    Independence matters more than count: a binary and the symlink pointing
+    at it are one FILESYSTEM observation of one fact, and M5 must not treat
+    them as two agreeing channels.
+    """
+
+    FILESYSTEM = "filesystem"
+    PACKAGE = "package"
+    REGISTRY = "registry"
+    SIGNATURE = "signature"
+    CONFIG = "config"
+    RUNTIME = "runtime"
+    NETWORK = "network"
+    EXEC_JOURNAL = "exec_journal"
+    TELEMETRY = "telemetry"
+
+
+class Rung(str, Enum):
+    """The evidence ladder, cheapest and strongest first (M4).
+
+    A candidate stops climbing as soon as it has proof. CONVENTION raises
+    priority and never concludes -- see `Verdict.is_concluded`.
+    """
+
+    PROVENANCE = "provenance"
+    CONTENT = "content"
+    BEHAVIOUR = "behaviour"
+    CONVENTION = "convention"
+
+
+#: The rungs that may, on their own, establish an identity.
+CONCLUSIVE_RUNGS = frozenset({Rung.PROVENANCE, Rung.CONTENT, Rung.BEHAVIOUR})
+
+
+@dataclass(frozen=True, slots=True)
+class Evidence:
+    stage: str
+    channel: Channel
+    path: str
+    proof: str
+    confidence: float = 0.0
+    rung: Rung | None = None
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(f"confidence out of range: {self.confidence}")
+
+
+@dataclass(frozen=True, slots=True)
+class Band:
+    """Confidence, reported as a band with the evidence that produced it.
+
+    A band rather than a number because the underlying quantity -- how many
+    independent channels agree -- is small and discrete, and a float invites
+    a precision the input does not have.
+    """
+
+    label: str
+    channels: tuple[Channel, ...] = ()
+
+    @staticmethod
+    def from_channels(channels: Sequence[Channel]) -> "Band":
+        distinct = tuple(sorted({c for c in channels}, key=lambda c: c.value))
+        n = len(distinct)
+        label = "high" if n >= 3 else "medium" if n == 2 else "low" if n == 1 else "none"
+        return Band(label, distinct)

--- a/Discovery/adr_discovery/contracts/records.py
+++ b/Discovery/adr_discovery/contracts/records.py
@@ -1,0 +1,227 @@
+"""The records the stages hand each other.
+
+One type per stage boundary. A stage is a function from its input type to
+its output type, so these are the whole of the coupling between modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from ..redact import rules as redact
+from .evidence import Band, Evidence, Rung
+
+
+class Kind(str, Enum):
+    """Asset kinds. A category with no member here cannot be reported."""
+
+    CLI_AGENT = "cli_agent"
+    APP = "app"
+    AI_BROWSER = "ai_browser"
+    MODEL_RUNTIME = "model_runtime"
+    MODEL_WEIGHTS = "model_weights"
+    EXTENSION = "extension"
+    MCP_SERVER = "mcp_server"
+    MCP_BUNDLE = "mcp_bundle"
+    SKILL = "skill"
+    COMMAND = "command"
+    PLUGIN = "plugin"
+    OUTPUT_STYLE = "output_style"
+    AGENT_DEFINITION = "agent_definition"
+    HOOK = "hook"
+    INSTRUCTIONS = "instructions"
+    CI_AGENT = "ci_agent"
+    CLOUD_AGENT = "cloud_agent"
+    AGENT_PLATFORM = "agent_platform"
+
+
+class Liveness(str, Enum):
+    RUNNING = "running"
+    INSTALLED = "installed"
+    DECLARED_ONLY = "declared_only"
+
+
+class Priority(int, Enum):
+    """Known roots order the sweep; they no longer decide what exists."""
+
+    HOME = 0
+    CODE_ROOT = 1
+    SYSTEM = 2
+    BREADTH = 3
+
+
+@dataclass(frozen=True, slots=True)
+class Candidate:
+    """M2 output. Deliberately tool-agnostic: nothing here knows what any
+    particular tool is, which is why M2 can be tested with an empty catalog."""
+
+    kind: str
+    path: str
+    source: str
+    priority: Priority = Priority.BREADTH
+    detail: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class Declaration:
+    """M3 output. One record from one config surface.
+
+    Redaction is carried by this type rather than applied by whoever
+    constructs it. A final pass is something a stage added tomorrow can be
+    placed behind; a constructor is not. `__post_init__` scrubs the fields
+    that can hold a secret, so a new extractor that never heard of C2 still
+    cannot emit one.
+    """
+
+    kind: Kind
+    name: str
+    path: str
+    scope: str = "user"
+    command: str | None = None
+    args: tuple[str, ...] = ()
+    env_names: tuple[str, ...] = ()
+    url: str | None = None
+    raw: dict[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "args", redact.scrub_argv(self.args))
+        if self.url is not None:
+            object.__setattr__(self, "url", redact.strip_url(self.url))
+        # An env *mapping* must never survive as one: names only.
+        env = self.raw.get("env")
+        if isinstance(env, dict):
+            scrubbed = dict(self.raw)
+            scrubbed["env"] = redact.env_names(env)
+            object.__setattr__(self, "raw", scrubbed)
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractError:
+    """A record that failed to parse. Isolation is per record, so this
+    coexists with its valid siblings rather than replacing them."""
+
+    path: str
+    index: int | None
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class Extraction:
+    """Declarations plus the true count -- which is what makes the isolation
+    claim measurable. `declared` counts records present in the file, not
+    records that survived parsing."""
+
+    declarations: tuple[Declaration, ...] = ()
+    errors: tuple[ExtractError, ...] = ()
+    declared: int = 0
+    truncated: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Verdict:
+    """M4 output. `rung` says which evidence established identity, so a
+    reader can tell a package-owned binary from a filename that looked right."""
+
+    catalog_id: str | None
+    kind: Kind | None
+    name: str | None = None
+    vendor: str | None = None
+    version: str | None = None
+    rung: Rung | None = None
+    evidence: tuple[Evidence, ...] = ()
+    signals: tuple[str, ...] = ()
+    score: float = 0.0
+    conflict: str | None = None
+
+    @property
+    def is_concluded(self) -> bool:
+        """True only when a conclusive rung produced the identity.
+
+        Convention raises priority and never concludes, so a verdict resting
+        on it alone is not an identification however plausible it reads.
+        """
+        from .evidence import CONCLUSIVE_RUNGS
+
+        return self.kind is not None and self.rung in CONCLUSIVE_RUNGS
+
+
+@dataclass(frozen=True, slots=True)
+class Observation:
+    """What M5 merges. One sighting of one thing, by one channel."""
+
+    kind: Kind
+    identity: str
+    path: str | None = None
+    install_root: str | None = None
+    owner: str | None = None
+    version: str | None = None
+    catalog_id: str | None = None
+    content_hash: str | None = None
+    real_path: str | None = None
+    inode: str | None = None
+    package_id: str | None = None
+    signature_id: str | None = None
+    liveness: Liveness = Liveness.INSTALLED
+    attribute_of: str | None = None
+    evidence: tuple[Evidence, ...] = ()
+    detail: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class Risk:
+    pinned: bool | None = None
+    factors: tuple[str, ...] = ()
+    credential_kinds: tuple[str, ...] = ()
+    env_names: tuple[str, ...] = ()
+    transport: str | None = None
+    destinations: tuple[str, ...] = ()
+    unattended: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Asset:
+    """M5 output, judged by M6, serialized by M7."""
+
+    asset_id: str
+    kind: Kind
+    name: str
+    identity: str
+    catalog_id: str | None = None
+    vendor: str | None = None
+    version: str | None = None
+    install_path: str | None = None
+    install_root: str | None = None
+    install_method: str | None = None
+    owner: str = "system"
+    location: str = "local"
+    liveness: Liveness = Liveness.INSTALLED
+    last_used: str | None = None
+    confidence: Band = field(default_factory=lambda: Band("none"))
+    verification: tuple[Rung, ...] = ()
+    evidence: tuple[Evidence, ...] = ()
+    risk: Risk = field(default_factory=Risk)
+    sanction: str = "unknown"
+    flags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """M6 output. Precision is asserted here, not just recall -- every
+    finding an operator dismisses costs the ones that follow it."""
+
+    rule: str
+    severity: str
+    asset_id: str
+    summary: str
+    evidence: tuple[Evidence, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewItem:
+    """Probable AI, unclassified. Triage, never a finding."""
+
+    path: str
+    score: float
+    signals: tuple[str, ...]
+    evidence: tuple[Evidence, ...] = ()

--- a/Discovery/adr_discovery/contracts/snapshot.py
+++ b/Discovery/adr_discovery/contracts/snapshot.py
@@ -1,0 +1,106 @@
+"""The output shape: a snapshot, and the coverage that travels with it.
+
+Coverage is a field of the answer rather than a log beside it, because the
+rule it exists to enforce is a rule about the answer: every asset that
+exists and is not in the snapshot must be explained by a record here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .records import Asset, Finding, ReviewItem
+
+SCHEMA_VERSION = "1.0"
+
+#: Categories discovery deliberately does not collect. Named rather than
+#: omitted, so a reader can tell a clean machine from an unasked question.
+OUT_OF_SCOPE: tuple[str, ...] = (
+    "instruction_files",
+    "agent_hooks",
+    "scheduling_mechanisms",
+)
+
+
+class Boundary(str):
+    """Why a walk or a read stopped."""
+
+    DEPTH = "depth"
+    ENTRY_CAP = "entry_cap"
+    BUDGET = "budget_exhausted"
+    TIME = "time_exhausted"
+
+
+@dataclass(frozen=True, slots=True)
+class RootSwept:
+    path: str
+    depth_reached: int
+    entries: int
+
+
+@dataclass(frozen=True, slots=True)
+class BoundaryHit:
+    path: str
+    boundary: str
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class Denied:
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class Unavailable:
+    provider: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class Truncated:
+    path: str
+    kept: int
+    true_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeRun:
+    name: str
+    status: str  # ran | degraded | failed
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class Coverage:
+    """What this scan did not see. An empty snapshot with empty coverage is
+    a claim that the machine is clean; an empty snapshot with records here
+    is a claim that we could not tell."""
+
+    roots_swept: tuple[RootSwept, ...] = ()
+    boundaries_hit: tuple[BoundaryHit, ...] = ()
+    denied: tuple[Denied, ...] = ()
+    unavailable: tuple[Unavailable, ...] = ()
+    truncated: tuple[Truncated, ...] = ()
+    probes: tuple[ProbeRun, ...] = ()
+    out_of_scope: tuple[str, ...] = OUT_OF_SCOPE
+
+    @property
+    def is_complete(self) -> bool:
+        """No surface went unread. Note this is never a claim that the
+        inventory is complete -- only that nothing is known to be missing."""
+        return not (self.boundaries_hit or self.denied or self.unavailable or self.truncated)
+
+
+@dataclass(frozen=True, slots=True)
+class Snapshot:
+    hostname: str
+    username: str
+    platform: str
+    timestamp: str
+    assets: tuple[Asset, ...] = ()
+    findings: tuple[Finding, ...] = ()
+    review_queue: tuple[ReviewItem, ...] = ()
+    coverage: Coverage = field(default_factory=Coverage)
+    catalog_version: str = "unknown"
+    schema_version: str = SCHEMA_VERSION


### PR DESCRIPTION
Adds typed evidence, candidate, declaration, observation, asset, finding, review, coverage, and snapshot contracts.\n\nStack: 2/14. Depends on discovery-redact.\n\nValidation at stack tip: 218 tests passed; Ruff passed.