### PR TITLE
feat(discovery): add guarded world access

### DIFF
--- a/Discovery/adr_discovery/world/budget.py
+++ b/Discovery/adr_discovery/world/budget.py
@@ -1,0 +1,51 @@
+"""Budgets live in M1, not in callers.
+
+A caller cannot forget a limit it does not set. One ceiling is shared by
+the whole scan rather than one per probe, because five private budgets
+cannot be reasoned about and, in aggregate, are not a budget at all.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class Budget:
+    """Ceilings for one scan. Mutable only in the consumed counters."""
+
+    max_read_bytes: int = 4 * 1024 * 1024
+    max_entries: int = 200_000
+    max_depth: int = 12
+    max_subprocess_seconds: float = 5.0
+    max_strings_bytes: int = 512 * 1024
+    #: The whole scan, wall clock. Plane A promises seconds, and a promise
+    #: with no ceiling behind it is a hope.
+    max_seconds: float = 120.0
+
+    entries_used: int = field(default=0, init=False)
+    started: float = field(default_factory=time.monotonic, init=False)
+
+    def take_entries(self, n: int = 1) -> bool:
+        """Consume from the shared entry ceiling. False once exhausted."""
+        if self.entries_used >= self.max_entries:
+            return False
+        self.entries_used += n
+        return True
+
+    @property
+    def entries_exhausted(self) -> bool:
+        return self.entries_used >= self.max_entries
+
+    @property
+    def seconds_used(self) -> float:
+        return time.monotonic() - self.started
+
+    @property
+    def time_exhausted(self) -> bool:
+        return self.seconds_used >= self.max_seconds
+
+    @property
+    def entries_remaining(self) -> int:
+        return max(0, self.max_entries - self.entries_used)

--- a/Discovery/adr_discovery/world/gate.py
+++ b/Discovery/adr_discovery/world/gate.py
@@ -1,0 +1,384 @@
+"""M1 -- the single door between the collector and the machine.
+
+Everything else in this design is testable only because this module
+exists: below the gate, a fixture directory and a live machine are
+interchangeable, which is what lets the whole pipeline be graded.
+
+Order is fixed and is the point:
+
+    canonicalize -> contain -> deny-list -> open -> verify the descriptor -> read under budget
+
+Containment and denial are decided on the *resolved* target rather than the
+path handed in, because a permitted config can be a symlink into a personal
+directory, and a relative segment inside a config can climb out of the tree.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Generic, Iterator, TypeVar
+
+from ..coverage.ledger import Ledger
+from ..redact import rules as redact
+from .budget import Budget
+from .platform.base import Providers
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class Ok(Generic[T]):
+    value: T
+
+    ok: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class Refused:
+    """Never an empty result that could equally mean 'nothing there' and
+    'could not look'. The reason is recorded where it is still known."""
+
+    reason: str
+    detail: str = ""
+
+    ok: bool = False
+
+
+Result = Ok[T] | Refused
+
+
+@dataclass(frozen=True, slots=True)
+class Entry:
+    path: str
+    is_dir: bool
+    is_symlink: bool
+    size: int
+    is_exec: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Stat:
+    path: str
+    real_path: str
+    inode: str
+    size: int
+    mode: int
+    mtime: float
+    owner: str
+
+
+@dataclass(frozen=True, slots=True)
+class Ran:
+    argv: tuple[str, ...]
+    code: int
+    stdout: str
+
+
+class Gate:
+    """The only object in the package that touches the host."""
+
+    def __init__(
+        self,
+        root: str = "/",
+        *,
+        ledger: Ledger | None = None,
+        budget: Budget | None = None,
+        providers: Providers | None = None,
+        env: dict[str, str] | None = None,
+        allow_subprocess: bool = True,
+    ) -> None:
+        self._root = os.path.realpath(root)
+        self.ledger = ledger if ledger is not None else Ledger()
+        self.budget = budget if budget is not None else Budget()
+        self.env = dict(env) if env is not None else {}
+        self.allow_subprocess = allow_subprocess
+        from .platform.base import NullProviders
+
+        self.providers = providers if providers is not None else NullProviders()
+        #: Call counters, so a test can assert the evidence ladder stopped
+        #: early rather than merely reaching the right answer expensively.
+        self.calls: dict[str, int] = {"read_bytes": 0, "run": 0, "package_owner": 0}
+        #: Test hook. Called with the resolved path immediately after
+        #: validation and before open(), so a case can swap the target and
+        #: prove the descriptor check catches it.
+        self.on_validated = None
+
+    # ---------------------------------------------------------------- paths
+
+    @property
+    def root(self) -> str:
+        return self._root
+
+    def host_path(self, logical: str) -> str:
+        """Map a logical (machine) path into this world."""
+        if self._root == "/":
+            return logical
+        return os.path.join(self._root, logical.lstrip("/\\"))
+
+    def logical_path(self, host: str) -> str:
+        """Inverse of `host_path`, so records read the same in a fixture and
+        on a real machine."""
+        if self._root == "/":
+            return host
+        if host == self._root:
+            return "/"
+        if host.startswith(self._root + os.sep):
+            return "/" + host[len(self._root) + 1 :]
+        return host
+
+    def _validate(self, logical: str) -> Result[str]:
+        """Canonicalize, then decide. Returns the resolved host path."""
+        candidate = self.host_path(logical)
+        try:
+            resolved = os.path.realpath(candidate)
+        except (OSError, ValueError) as exc:
+            return Refused("unresolvable", str(exc))
+
+        if self._root != "/" and not (
+            resolved == self._root or resolved.startswith(self._root + os.sep)
+        ):
+            self.ledger.deny(logical, "outside_root")
+            return Refused("outside_root", self.logical_path(resolved))
+
+        if redact.is_personal(self.logical_path(resolved)):
+            self.ledger.deny(logical, "personal_path")
+            return Refused("personal_path", "")
+
+        return Ok(resolved)
+
+    # ---------------------------------------------------------------- reads
+
+    def _open_verified(self, resolved: str) -> Result[int]:
+        """Checking a path and opening it are two operations.
+
+        The descriptor is compared against the validated target, so a swap
+        between the two is a refusal rather than a read.
+        """
+        try:
+            before = os.stat(resolved, follow_symlinks=False)
+        except FileNotFoundError:
+            return Refused("absent", resolved)
+        except OSError as exc:
+            return Refused("stat_failed", exc.strerror or str(exc))
+
+        if self.on_validated is not None:
+            self.on_validated(resolved)
+
+        try:
+            fd = os.open(resolved, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        except OSError as exc:
+            # The target was already resolved, so it cannot legitimately be a
+            # symlink by the time we open it. ELOOP here means the path was
+            # replaced between the check and the open.
+            if exc.errno == errno.ELOOP:
+                return Refused("swapped", "target became a symlink after validation")
+            return Refused("open_failed", exc.strerror or str(exc))
+
+        after = os.fstat(fd)
+        if (after.st_dev, after.st_ino) != (before.st_dev, before.st_ino):
+            os.close(fd)
+            return Refused("swapped", "descriptor did not match the validated target")
+        return Ok(fd)
+
+    def read_bytes(self, logical: str, limit: int | None = None) -> Result[bytes]:
+        self.calls["read_bytes"] += 1
+        validated = self._validate(logical)
+        if not validated.ok:
+            return validated
+        resolved = validated.value
+        ceiling = self.budget.max_read_bytes if limit is None else min(limit, self.budget.max_read_bytes)
+
+        opened = self._open_verified(resolved)
+        if not opened.ok:
+            if opened.reason in ("open_failed", "stat_failed"):
+                self.ledger.deny(logical, opened.detail or opened.reason)
+            elif opened.reason == "swapped":
+                self.ledger.deny(logical, "target swapped after validation")
+            return opened
+        fd = opened.value
+        try:
+            size = os.fstat(fd).st_size
+            data = os.read(fd, ceiling)
+        finally:
+            os.close(fd)
+
+        if size > ceiling:
+            self.ledger.truncate(logical, len(data), size)
+            return Ok(data)
+        return Ok(data)
+
+    def read_text(self, logical: str, limit: int | None = None) -> Result[str]:
+        raw = self.read_bytes(logical, limit)
+        if not raw.ok:
+            return raw
+        return Ok(raw.value.decode("utf-8", errors="replace"))
+
+    def stat(self, logical: str) -> Result[Stat]:
+        validated = self._validate(logical)
+        if not validated.ok:
+            return validated
+        resolved = validated.value
+        try:
+            st = os.stat(resolved)
+        except FileNotFoundError:
+            return Refused("absent", logical)
+        except OSError as exc:
+            self.ledger.deny(logical, exc.strerror or str(exc))
+            return Refused("stat_failed", exc.strerror or str(exc))
+        return Ok(
+            Stat(
+                path=logical,
+                real_path=self.logical_path(resolved),
+                inode=f"{st.st_dev}:{st.st_ino}",
+                size=st.st_size,
+                mode=st.st_mode,
+                mtime=st.st_mtime,
+                owner=self.providers.owner_of(st.st_uid),
+            )
+        )
+
+    def list_dir(self, logical: str) -> Result[tuple[Entry, ...]]:
+        validated = self._validate(logical)
+        if not validated.ok:
+            return validated
+        resolved = validated.value
+        try:
+            raw = sorted(os.scandir(resolved), key=lambda e: e.name)
+        except FileNotFoundError:
+            # Absent is not denied. A surface that does not exist was not
+            # refused, and recording it here would drown the real refusals
+            # and make `coverage.is_complete` meaningless.
+            return Refused("absent", logical)
+        except OSError as exc:
+            self.ledger.deny(logical, exc.strerror or str(exc))
+            return Refused("listdir_failed", exc.strerror or str(exc))
+
+        entries: list[Entry] = []
+        for e in raw:
+            try:
+                info = e.stat(follow_symlinks=False)
+                entries.append(
+                    Entry(
+                        path=os.path.join(logical, e.name) if logical != "/" else "/" + e.name,
+                        is_dir=e.is_dir(follow_symlinks=False),
+                        is_symlink=e.is_symlink(),
+                        size=info.st_size,
+                        is_exec=bool(info.st_mode & 0o111) and not e.is_dir(follow_symlinks=False),
+                    )
+                )
+            except OSError:
+                continue
+        return Ok(tuple(entries))
+
+    def walk(self, logical_root: str, max_depth: int | None = None) -> Iterator[Entry]:
+        """Breadth-first under the shared entry ceiling.
+
+        Breadth-first on purpose: a budget exhausted late still covered the
+        likely places, which is not true of a depth-first walk that spends
+        everything in the first deep subtree it meets.
+        """
+        depth_cap = self.budget.max_depth if max_depth is None else max_depth
+        frontier: list[tuple[str, int]] = [(logical_root, 0)]
+        seen: set[str] = set()
+        deepest = 0
+        count = 0
+
+        while frontier:
+            path, depth = frontier.pop(0)
+            if depth > depth_cap:
+                self.ledger.boundary(path, "depth", f"cap {depth_cap}")
+                continue
+            if self.budget.time_exhausted:
+                self.ledger.boundary(path, "time_exhausted", f"cap {self.budget.max_seconds}s")
+                self.ledger.swept(logical_root, deepest, count)
+                return
+            listing = self.list_dir(path)
+            if not listing.ok:
+                continue
+            deepest = max(deepest, depth)
+            for entry in listing.value:
+                if not self.budget.take_entries():
+                    self.ledger.boundary(path, "budget_exhausted", f"cap {self.budget.max_entries}")
+                    self.ledger.swept(logical_root, deepest, count)
+                    return
+                count += 1
+                yield entry
+                if entry.is_dir and not entry.is_symlink and entry.path not in seen:
+                    seen.add(entry.path)
+                    frontier.append((entry.path, depth + 1))
+
+        self.ledger.swept(logical_root, deepest, count)
+
+    # ------------------------------------------------------------ processes
+
+    def processes(self):
+        return self.providers.processes(self)
+
+    def sockets(self):
+        return self.providers.sockets(self)
+
+    def packages(self):
+        return self.providers.packages(self)
+
+    def applications(self):
+        return self.providers.applications(self)
+
+    def dns_cache(self):
+        return self.providers.dns_cache(self)
+
+    def exec_journal(self):
+        return self.providers.exec_journal(self)
+
+    def package_owner(self, path: str):
+        self.calls["package_owner"] += 1
+        return self.providers.package_owner(self, path)
+
+    # ----------------------------------------------------------- subprocess
+
+    def run(self, argv: tuple[str, ...], timeout: float | None = None) -> Result[Ran]:
+        """One sandboxed subprocess, under the budget's time ceiling.
+
+        The executable is resolved through the world like every other path,
+        so a caller passes the same logical path it would pass to a read.
+        Without that, a fixture and a live machine are not interchangeable
+        and every case has to know which one it is running against.
+
+        Output is capped and a timeout is a recorded refusal, so partial
+        output can never be mistaken for a version string.
+        """
+        self.calls["run"] += 1
+        if not self.allow_subprocess:
+            return Refused("subprocess_disabled", "")
+        if not argv:
+            return Refused("no_argv", "")
+        if self.budget.time_exhausted:
+            self.ledger.probe(argv[0], "failed", "scan time budget exhausted")
+            return Refused("time_budget_exhausted", f"{self.budget.max_seconds}s")
+
+        target = argv[0]
+        if self._root != "/" and target.startswith("/"):
+            validated = self._validate(target)
+            if not validated.ok:
+                return validated
+            target = validated.value
+
+        limit = self.budget.max_subprocess_seconds if timeout is None else timeout
+        try:
+            proc = subprocess.run(
+                [target, *argv[1:]],
+                capture_output=True,
+                text=True,
+                timeout=limit,
+                env={"PATH": self.env.get("PATH", "/usr/bin:/bin"), "LC_ALL": "C"},
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            self.ledger.probe(argv[0] if argv else "?", "failed", "timeout")
+            return Refused("timeout", f"{limit}s")
+        except (OSError, ValueError) as exc:
+            self.ledger.probe(argv[0] if argv else "?", "failed", str(exc))
+            return Refused("spawn_failed", str(exc))
+        return Ok(Ran(tuple(argv), proc.returncode, proc.stdout[:8192]))

--- a/Discovery/adr_discovery/world/platform/__init__.py
+++ b/Discovery/adr_discovery/world/platform/__init__.py
@@ -1,0 +1,24 @@
+"""Platform selection. The only place an OS difference may exist."""
+
+from __future__ import annotations
+
+import sys
+
+from .base import FixtureProviders as FixtureProviders
+from .base import NullProviders, Providers
+
+
+def for_host() -> Providers:
+    if sys.platform == "darwin":
+        from .darwin import DarwinProviders
+
+        return DarwinProviders()
+    if sys.platform.startswith("linux"):
+        from .linux import LinuxProviders
+
+        return LinuxProviders()
+    if sys.platform.startswith("win"):
+        from .windows import WindowsProviders
+
+        return WindowsProviders()
+    return NullProviders()

--- a/Discovery/adr_discovery/world/platform/base.py
+++ b/Discovery/adr_discovery/world/platform/base.py
@@ -1,0 +1,338 @@
+"""Provider shapes, and the two providers that need no OS at all.
+
+The only place an OS difference may exist is under this package. Everything
+above it sees these dataclasses and nothing else, which is what makes a
+fixture world and a live machine interchangeable.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..gate import Gate, Result
+
+
+@dataclass(frozen=True, slots=True)
+class Process:
+    pid: int
+    exe: str
+    """The link target of /proc/<pid>/exe, or its platform equivalent.
+
+    Never a name. `ps comm=` truncates at fifteen characters on Linux, and
+    resolving that name against PATH attributes /opt/agents/claude to
+    /usr/bin/claude -- a different binary.
+    """
+    argv: tuple[str, ...] = ()
+    ppid: int = 0
+    cwd: str | None = None
+    user: str = "system"
+    env_names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class Socket:
+    proto: str
+    state: str  # LISTEN | ESTABLISHED
+    local_port: int = 0
+    remote_host: str = ""
+    remote_port: int = 0
+    pid: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Package:
+    manager: str
+    name: str
+    version: str | None = None
+    path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Application:
+    ident: str
+    name: str
+    version: str | None = None
+    vendor: str | None = None
+    path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DnsEntry:
+    hostname: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExecEvent:
+    """What ran between scans. Absent unless a privileged collector supplies
+    it -- and its absence is a coverage fact, never an empty set."""
+
+    exe: str
+    argv: tuple[str, ...] = ()
+    ppid: int = 0
+    parent_exe: str | None = None
+    started: str = ""
+
+
+class Providers(Protocol):
+    def home_roots(self) -> tuple[str, ...]: ...
+    def owner_of(self, uid: int) -> str: ...
+    def processes(self, gate: "Gate") -> "Result": ...
+    def sockets(self, gate: "Gate") -> "Result": ...
+    def packages(self, gate: "Gate") -> "Result": ...
+    def applications(self, gate: "Gate") -> "Result": ...
+    def dns_cache(self, gate: "Gate") -> "Result": ...
+    def exec_journal(self, gate: "Gate") -> "Result": ...
+    def package_owner(self, gate: "Gate", path: str) -> "Result": ...
+
+
+class NullProviders:
+    """Every query is unavailable, with a reason.
+
+    This is the correct provider for a platform nobody has implemented yet:
+    it makes the gap appear in coverage instead of making the machine look
+    clean, which is the difference the whole design turns on.
+    """
+
+    reason = "no provider for this platform"
+
+    #: Where user homes live. A platform question, and therefore not one
+    #: M2 may answer: on macOS `/home` is an autofs mount that blocks a
+    #: lister for as long as automountd feels like it, and a scan that
+    #: hangs there is indistinguishable from a scan that found nothing.
+    HOME_ROOTS: tuple[str, ...] = ("/Users", "/home")
+
+    def home_roots(self) -> tuple[str, ...]:
+        return self.HOME_ROOTS
+
+    def owner_of(self, uid: int) -> str:
+        return "system"
+
+    def _unavailable(self, gate: "Gate", name: str):
+        from ..gate import Refused
+
+        gate.ledger.unavailable(name, self.reason)
+        return Refused("unavailable", self.reason)
+
+    def processes(self, gate):
+        return self._unavailable(gate, "processes")
+
+    def sockets(self, gate):
+        return self._unavailable(gate, "sockets")
+
+    def packages(self, gate):
+        return self._unavailable(gate, "packages")
+
+    def applications(self, gate):
+        return self._unavailable(gate, "applications")
+
+    def dns_cache(self, gate):
+        return self._unavailable(gate, "dns_cache")
+
+    def exec_journal(self, gate):
+        return self._unavailable(gate, "exec_journal")
+
+    def package_owner(self, gate, path):
+        return self._unavailable(gate, "package_owner")
+
+
+class LanguagePackages:
+    """Package databases that are the same on every platform.
+
+    npm, pipx, uv, cargo and go keep their manifests on disk in the same
+    shape everywhere, so reading them is not an OS difference and does not
+    belong in a per-platform provider. Every read goes through the gate,
+    so a fixture tree answers these exactly as a real machine does.
+    """
+
+    NODE_ROOTS = (
+        "/usr/local/lib/node_modules", "/opt/homebrew/lib/node_modules",
+        "/usr/lib/node_modules", "~/.npm-global/lib/node_modules",
+        "~/.nvm/versions/node", "~/node_modules",
+    )
+    PIPX_ROOTS = ("~/.local/pipx/venvs", "~/.local/share/pipx/venvs")
+    UV_ROOTS = ("~/.local/share/uv/tools",)
+    BIN_ROOTS = ("~/.cargo/bin", "~/go/bin", "~/.local/bin")
+
+    def collect(self, gate, homes: tuple[str, ...]) -> list[Package]:
+        found: list[Package] = []
+        found.extend(self._npm(gate, homes))
+        found.extend(self._venvs(gate, homes, self.PIPX_ROOTS, "pipx"))
+        found.extend(self._venvs(gate, homes, self.UV_ROOTS, "uv"))
+        found.extend(self._cargo(gate, homes))
+        found.extend(self._go(gate, homes))
+        return found
+
+    def _cargo(self, gate, homes) -> list[Package]:
+        out: list[Package] = []
+        for home in homes:
+            raw = gate.read_text(home + "/.cargo/.crates2.json", limit=4 << 20)
+            if not raw.ok:
+                continue
+            try:
+                document = json.loads(raw.value)
+            except ValueError:
+                gate.ledger.probe("cargo", "degraded", home + "/.cargo/.crates2.json")
+                continue
+            for key in (document.get("installs") or {}):
+                # Current Cargo uses "name version (source)" as the key.
+                parts = key.split()
+                if parts:
+                    name = parts[0]
+                    version = parts[1] if len(parts) > 1 else None
+                    out.append(Package("cargo", name, version, home + "/.cargo/bin"))
+        return out
+
+    def _go(self, gate, homes) -> list[Package]:
+        out: list[Package] = []
+        for home in homes:
+            listing = gate.list_dir(home + "/go/bin")
+            if not listing.ok:
+                continue
+            for entry in listing.value:
+                if entry.is_dir or not entry.is_exec:
+                    continue
+                ran = gate.run(("go", "version", "-m", entry.path))
+                if not ran.ok or ran.value.code != 0:
+                    continue
+                for line in ran.value.stdout.splitlines():
+                    fields = line.strip().split()
+                    if len(fields) >= 3 and fields[0] == "mod":
+                        out.append(Package("go", fields[1], fields[2], entry.path))
+                        break
+        return out
+
+    def _expand(self, template: str, homes: tuple[str, ...]) -> list[str]:
+        if not template.startswith("~"):
+            return [template]
+        return [home + template[1:] for home in homes]
+
+    def _npm(self, gate, homes) -> list[Package]:
+        import json as _json
+
+        out: list[Package] = []
+        for template in self.NODE_ROOTS:
+            for root in self._expand(template, homes):
+                listing = gate.list_dir(root)
+                if not listing.ok:
+                    continue
+                for entry in listing.value:
+                    if not entry.is_dir:
+                        continue
+                    name = entry.path.rsplit("/", 1)[-1]
+                    # Scoped packages hold their real entries one level down.
+                    targets = [entry.path]
+                    if name.startswith("@"):
+                        scoped = gate.list_dir(entry.path)
+                        targets = [e.path for e in scoped.value] if scoped.ok else []
+                    for target in targets:
+                        raw = gate.read_text(target + "/package.json", limit=1 << 20)
+                        if not raw.ok:
+                            continue
+                        try:
+                            manifest = _json.loads(raw.value)
+                        except ValueError:
+                            gate.ledger.probe("npm", "degraded", target)
+                            continue
+                        out.append(
+                            Package("npm", str(manifest.get("name") or ""),
+                                    _opt_str(manifest.get("version")), target)
+                        )
+        return out
+
+    def _venvs(self, gate, homes, roots, manager) -> list[Package]:
+        out: list[Package] = []
+        for template in roots:
+            for root in self._expand(template, homes):
+                listing = gate.list_dir(root)
+                if not listing.ok:
+                    continue
+                for entry in listing.value:
+                    if entry.is_dir:
+                        out.append(Package(manager, entry.path.rsplit("/", 1)[-1], None, entry.path))
+        return out
+
+
+def _opt_str(value):
+    return str(value) if value is not None else None
+
+
+class FixtureProviders(NullProviders):
+    """Reads the non-filesystem surfaces from JSON beside the fixture tree.
+
+    A surface with no file is *unavailable*, not empty -- so a case that
+    forgets to supply processes.json fails loudly rather than quietly
+    asserting that nothing was running.
+    """
+
+    reason = "not supplied by this fixture"
+
+    FILES = {
+        "processes": ("processes.json", Process),
+        "sockets": ("sockets.json", Socket),
+        "packages": ("packages.json", Package),
+        "applications": ("applications.json", Application),
+        "dns_cache": ("dns.json", DnsEntry),
+        "exec_journal": ("execjournal.json", ExecEvent),
+    }
+
+    def __init__(self, data: dict[str, object] | None = None) -> None:
+        self._data = data or {}
+
+    def _load(self, gate: "Gate", surface: str):
+        from ..gate import Ok
+
+        if surface in self._data:
+            rows = self._data[surface]
+        else:
+            filename, _ = self.FILES[surface]
+            raw = gate.read_text("/" + filename)
+            if not raw.ok:
+                return self._unavailable(gate, surface)
+            try:
+                rows = json.loads(raw.value)
+            except json.JSONDecodeError as exc:
+                gate.ledger.unavailable(surface, f"malformed fixture: {exc}")
+                from ..gate import Refused
+
+                return Refused("malformed", str(exc))
+        _, cls = self.FILES[surface]
+        out = []
+        for row in rows:
+            row = dict(row)
+            for key in ("argv", "env_names"):
+                if key in row and isinstance(row[key], list):
+                    row[key] = tuple(row[key])
+            out.append(cls(**row))
+        return Ok(tuple(out))
+
+    def processes(self, gate):
+        return self._load(gate, "processes")
+
+    def sockets(self, gate):
+        return self._load(gate, "sockets")
+
+    def packages(self, gate):
+        return self._load(gate, "packages")
+
+    def applications(self, gate):
+        return self._load(gate, "applications")
+
+    def dns_cache(self, gate):
+        return self._load(gate, "dns_cache")
+
+    def exec_journal(self, gate):
+        return self._load(gate, "exec_journal")
+
+    def package_owner(self, gate, path):
+        from ..gate import Ok, Refused
+
+        pkgs = self._load(gate, "packages")
+        if not pkgs.ok:
+            return pkgs
+        for pkg in pkgs.value:
+            if pkg.path and pkg.path == path:
+                return Ok(pkg)
+        return Refused("not_owned", path)

--- a/Discovery/adr_discovery/world/platform/darwin.py
+++ b/Discovery/adr_discovery/world/platform/darwin.py
@@ -1,0 +1,154 @@
+"""macOS providers.
+
+`ps -o comm=` returns a full executable path here rather than a truncated
+name, so the exe requirement is met without /proc.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import pwd
+
+from .base import Application, LanguagePackages, NullProviders, Package, Process, Socket
+
+
+class DarwinProviders(NullProviders):
+    reason = "not readable on this host"
+
+    #: `/home` is autofs here and blocks indefinitely when automountd is
+    #: unresponsive. Homes live under /Users; there is nothing to gain by
+    #: asking, and a hang to lose.
+    HOME_ROOTS = ("/Users",)
+
+    def _homes(self, gate) -> tuple[str, ...]:
+        out: list[str] = []
+        for base in self.home_roots():
+            listing = gate.list_dir(base)
+            if listing.ok:
+                out.extend(e.path for e in listing.value if e.is_dir)
+        return tuple(out)
+
+    def owner_of(self, uid: int) -> str:
+        try:
+            return pwd.getpwuid(uid).pw_name
+        except KeyError:
+            return str(uid)
+
+    def processes(self, gate):
+        from ..gate import Ok
+
+        ran = gate.run(("ps", "-axo", "pid=,ppid=,user=,comm="))
+        if not ran.ok or ran.value.code != 0:
+            return self._unavailable(gate, "processes")
+        procs: list[Process] = []
+        for line in ran.value.stdout.splitlines():
+            parts = line.strip().split(None, 3)
+            if len(parts) < 4:
+                continue
+            pid, ppid, user, exe = parts
+            if not pid.isdigit():
+                continue
+            procs.append(Process(pid=int(pid), exe=exe, ppid=int(ppid) if ppid.isdigit() else 0, user=user))
+        return Ok(tuple(procs))
+
+    def sockets(self, gate):
+        from ..gate import Ok
+
+        ran = gate.run(("lsof", "-nP", "-iTCP"))
+        if not ran.ok or ran.value.code != 0:
+            return self._unavailable(gate, "sockets")
+        out: list[Socket] = []
+        for line in ran.value.stdout.splitlines()[1:]:
+            cols = line.split()
+            if len(cols) < 9 or not cols[1].isdigit():
+                continue
+            endpoint = cols[8]
+            raw_state = cols[9].strip("()") if len(cols) > 9 else ""
+            state = "LISTEN" if raw_state == "LISTEN" else "ESTABLISHED" if "->" in endpoint else ""
+            if not state:
+                continue
+            local, _, remote = endpoint.partition("->")
+            _, lport = _split_colon_hostport(local)
+            rhost, rport = _split_colon_hostport(remote) if remote else ("", 0)
+            out.append(Socket("tcp", state, lport, rhost, rport, int(cols[1])))
+        return Ok(tuple(out))
+
+    def applications(self, gate):
+        from ..gate import Ok
+
+        apps: list[Application] = []
+        for root in ("/Applications", "/System/Applications"):
+            listing = gate.list_dir(root)
+            if not listing.ok:
+                continue
+            for entry in listing.value:
+                if not entry.path.endswith(".app"):
+                    continue
+                raw = gate.read_bytes(entry.path + "/Contents/Info.plist", limit=1 << 20)
+                if not raw.ok:
+                    continue
+                try:
+                    info = plistlib.loads(raw.value)
+                except Exception:
+                    gate.ledger.probe("Info.plist", "degraded", entry.path)
+                    continue
+                apps.append(
+                    Application(
+                        ident=str(info.get("CFBundleIdentifier", "")),
+                        name=str(info.get("CFBundleName", entry.path.rsplit("/", 1)[-1])),
+                        version=_str_or_none(info.get("CFBundleShortVersionString")),
+                        path=entry.path,
+                    )
+                )
+        if not apps:
+            return self._unavailable(gate, "applications")
+        return Ok(tuple(apps))
+
+    def dns_cache(self, gate):
+        # The macOS resolver cache has not been externally enumerable since
+        # the mDNSResponder rework. Say so; do not return an empty list.
+        gate.ledger.unavailable("dns_cache", "mDNSResponder cache is not enumerable")
+        from ..gate import Refused
+
+        return Refused("unavailable", "mDNSResponder cache is not enumerable")
+
+    def packages(self, gate):
+        from ..gate import Ok
+
+        found: list[Package] = []
+        found.extend(LanguagePackages().collect(gate, self._homes(gate)))
+        for cellar in ("/opt/homebrew/Cellar", "/usr/local/Cellar"):
+            listing = gate.list_dir(cellar)
+            if not listing.ok:
+                continue
+            for entry in listing.value:
+                if not entry.is_dir:
+                    continue
+                name = entry.path.rsplit("/", 1)[-1]
+                versions = gate.list_dir(entry.path)
+                version = (
+                    versions.value[-1].path.rsplit("/", 1)[-1] if versions.ok and versions.value else None
+                )
+                found.append(Package("brew", name, version, entry.path))
+        if not found:
+            return self._unavailable(gate, "packages")
+        return Ok(tuple(found))
+
+
+def _str_or_none(v):
+    return str(v) if v is not None else None
+
+
+def _port(hostport: str) -> int:
+    tail = hostport.rsplit(".", 1)[-1]
+    return int(tail) if tail.isdigit() else 0
+
+
+def _split_hostport(hostport: str) -> tuple[str, int]:
+    host, _, port = hostport.rpartition(".")
+    return host, int(port) if port.isdigit() else 0
+
+
+def _split_colon_hostport(value: str) -> tuple[str, int]:
+    host, sep, port = value.rpartition(":")
+    return (host, int(port)) if sep and port.isdigit() else (value, 0)

--- a/Discovery/adr_discovery/world/platform/linux.py
+++ b/Discovery/adr_discovery/world/platform/linux.py
@@ -1,0 +1,245 @@
+"""Linux providers. Processes come from /proc, never from a name."""
+
+from __future__ import annotations
+
+import os
+import pwd
+
+from .base import Application, LanguagePackages, NullProviders, Package, Process, Socket
+
+
+class LinuxProviders(NullProviders):
+    reason = "not readable on this host"
+
+    HOME_ROOTS = ("/home", "/root")
+
+    def _homes(self, gate) -> tuple[str, ...]:
+        out: list[str] = []
+        for base in self.home_roots():
+            listing = gate.list_dir(base)
+            if listing.ok:
+                out.extend(e.path for e in listing.value if e.is_dir)
+        return tuple(out)
+
+    def owner_of(self, uid: int) -> str:
+        try:
+            return pwd.getpwuid(uid).pw_name
+        except KeyError:
+            return str(uid)
+
+    def processes(self, gate):
+        from ..gate import Ok
+
+        procs: list[Process] = []
+        listing = gate.list_dir("/proc")
+        if not listing.ok:
+            return self._unavailable(gate, "processes")
+        for entry in listing.value:
+            name = entry.path.rsplit("/", 1)[-1]
+            if not name.isdigit():
+                continue
+            pid = int(name)
+            # The link target, not the name: one syscall, and it is the
+            # difference between /opt/agents/claude and /usr/bin/claude.
+            try:
+                exe = os.readlink(gate.host_path(f"/proc/{pid}/exe"))
+            except OSError:
+                continue
+            cmdline = gate.read_bytes(f"/proc/{pid}/cmdline", limit=8192)
+            argv = tuple(cmdline.value.decode("utf-8", "replace").split("\0")[:-1]) if cmdline.ok else ()
+            try:
+                cwd = os.readlink(gate.host_path(f"/proc/{pid}/cwd"))
+            except OSError:
+                cwd = None
+            status = gate.read_text(f"/proc/{pid}/status", limit=4096)
+            ppid, uid = 0, 0
+            if status.ok:
+                for line in status.value.splitlines():
+                    if line.startswith("PPid:"):
+                        ppid = int(line.split()[1])
+                    elif line.startswith("Uid:"):
+                        uid = int(line.split()[1])
+            environ = gate.read_bytes(f"/proc/{pid}/environ", limit=32768)
+            env_names = ()
+            if environ.ok:
+                env_names = tuple(
+                    sorted(
+                        {
+                            part.split("=", 1)[0]
+                            for part in environ.value.decode("utf-8", "replace").split("\0")
+                            if "=" in part
+                        }
+                    )
+                )
+            procs.append(
+                Process(pid=pid, exe=exe, argv=argv, ppid=ppid, cwd=cwd,
+                        user=self.owner_of(uid), env_names=env_names)
+            )
+        return Ok(tuple(procs))
+
+    def sockets(self, gate):
+        from ..gate import Ok
+
+        out: list[Socket] = []
+        inode_pids = _socket_pids(gate)
+        for proto, path in (("tcp", "/proc/net/tcp"), ("tcp6", "/proc/net/tcp6")):
+            raw = gate.read_text(path, limit=1 << 20)
+            if not raw.ok:
+                continue
+            for line in raw.value.splitlines()[1:]:
+                cols = line.split()
+                if len(cols) < 4:
+                    continue
+                try:
+                    lport = int(cols[1].split(":")[1], 16)
+                    rhex, rport_hex = cols[2].split(":")
+                    rport = int(rport_hex, 16)
+                    inode = cols[9]
+                except (ValueError, IndexError):
+                    continue
+                state = {"0A": "LISTEN", "01": "ESTABLISHED"}.get(cols[3], cols[3])
+                if state not in ("LISTEN", "ESTABLISHED"):
+                    continue
+                out.append(
+                    Socket(proto=proto, state=state, local_port=lport,
+                           remote_host=_hex_ip(rhex), remote_port=rport,
+                           pid=inode_pids.get(inode))
+                )
+        if not out:
+            return self._unavailable(gate, "sockets")
+        return Ok(tuple(out))
+
+    def packages(self, gate):
+        from ..gate import Ok
+
+        found: list[Package] = []
+        found.extend(LanguagePackages().collect(gate, self._homes(gate)))
+        status = gate.read_text("/var/lib/dpkg/status", limit=8 << 20)
+        if status.ok:
+            name = version = None
+            for line in status.value.splitlines():
+                if line.startswith("Package: "):
+                    name = line[9:].strip()
+                elif line.startswith("Version: "):
+                    version = line[9:].strip()
+                elif not line.strip() and name:
+                    found.append(Package("dpkg", name, version))
+                    name = version = None
+        else:
+            gate.ledger.unavailable("dpkg", "status file not readable")
+
+        apk = gate.read_text("/lib/apk/db/installed", limit=8 << 20)
+        if apk.ok:
+            name = version = None
+            for line in apk.value.splitlines() + [""]:
+                if line.startswith("P:"):
+                    name = line[2:]
+                elif line.startswith("V:"):
+                    version = line[2:]
+                elif not line and name:
+                    found.append(Package("apk", name, version))
+                    name = version = None
+
+        for root, manager in (("/var/lib/snapd/snaps", "snap"), ("/var/lib/flatpak/app", "flatpak")):
+            listing = gate.list_dir(root)
+            if not listing.ok:
+                continue
+            for entry in listing.value:
+                name = entry.path.rsplit("/", 1)[-1]
+                if manager == "snap" and name.endswith(".snap"):
+                    stem = name[:-5]
+                    pkg, _, version = stem.rpartition("_")
+                    found.append(Package(manager, pkg or stem, version or None, entry.path))
+                elif manager == "flatpak" and entry.is_dir:
+                    found.append(Package(manager, name, None, entry.path))
+
+        rpm = gate.run(("rpm", "-qa", "--qf", "%{NAME}\\t%{VERSION}-%{RELEASE}\\n"))
+        if rpm.ok and rpm.value.code == 0:
+            for line in rpm.value.stdout.splitlines():
+                name, sep, version = line.partition("\t")
+                if sep:
+                    found.append(Package("rpm", name, version))
+        if not found:
+            return self._unavailable(gate, "packages")
+        return Ok(tuple(found))
+
+    def applications(self, gate):
+        from ..gate import Ok
+
+        apps: list[Application] = []
+        for root in ("/usr/share/applications", "/var/lib/flatpak/exports/share/applications"):
+            listing = gate.list_dir(root)
+            if not listing.ok:
+                continue
+            for entry in listing.value:
+                if not entry.path.endswith(".desktop"):
+                    continue
+                raw = gate.read_text(entry.path, limit=65536)
+                if not raw.ok:
+                    continue
+                fields = dict(
+                    line.split("=", 1) for line in raw.value.splitlines() if "=" in line and not line.startswith("#")
+                )
+                apps.append(
+                    Application(
+                        ident=entry.path.rsplit("/", 1)[-1].removesuffix(".desktop"),
+                        name=fields.get("Name", ""),
+                        version=fields.get("Version"),
+                        path=fields.get("Exec"),
+                    )
+                )
+        if not apps:
+            return self._unavailable(gate, "applications")
+        return Ok(tuple(apps))
+
+    def dns_cache(self, gate):
+        ran = gate.run(("resolvectl", "statistics"))
+        if not ran.ok:
+            return self._unavailable(gate, "dns_cache")
+        # resolvectl exposes counters, not entries, on most builds. Report
+        # the surface as unavailable rather than inventing an empty answer.
+        gate.ledger.unavailable("dns_cache", "resolvectl exposes counters, not cache entries")
+        from ..gate import Refused
+
+        return Refused("unavailable", "no enumerable resolver cache")
+
+    def package_owner(self, gate, path):
+        from ..gate import Ok, Refused
+
+        ran = gate.run(("dpkg", "-S", path))
+        if not ran.ok:
+            return ran
+        if ran.value.code != 0 or ":" not in ran.value.stdout:
+            return Refused("not_owned", path)
+        pkg = ran.value.stdout.split(":", 1)[0].strip()
+        return Ok(Package("dpkg", pkg, None, path))
+
+
+def _hex_ip(hex_addr: str) -> str:
+    if len(hex_addr) == 8:
+        octets = [int(hex_addr[i : i + 2], 16) for i in (6, 4, 2, 0)]
+        return ".".join(str(o) for o in octets)
+    return hex_addr
+
+
+def _socket_pids(gate) -> dict[str, int]:
+    """Join /proc/net socket inodes back to their owning processes."""
+    owners: dict[str, int] = {}
+    procs = gate.list_dir("/proc")
+    if not procs.ok:
+        return owners
+    for proc in procs.value:
+        name = proc.path.rsplit("/", 1)[-1]
+        if not name.isdigit() or not proc.is_dir:
+            continue
+        fds = gate.list_dir(proc.path + "/fd")
+        if not fds.ok:
+            continue
+        for fd in fds.value:
+            try:
+                target = os.readlink(gate.host_path(fd.path))
+            except OSError:
+                continue
+            if target.startswith("socket:[") and target.endswith("]"):
+                owners[target[8:-1]] = int(name)
+    return owners

--- a/Discovery/adr_discovery/world/platform/windows.py
+++ b/Discovery/adr_discovery/world/platform/windows.py
@@ -1,0 +1,91 @@
+"""Windows providers: CIM, TCP tables, Uninstall registry and AppX."""
+
+from __future__ import annotations
+
+import json
+import shlex
+
+from .base import Application, NullProviders, Package, Process, Socket
+
+
+class WindowsProviders(NullProviders):
+    reason = "Windows management surface unavailable"
+    HOME_ROOTS = ("/Users",)
+
+    def processes(self, gate):
+        rows = self._ps_json(gate, "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,ExecutablePath,CommandLine | ConvertTo-Json -Compress", "processes")
+        if rows is None:
+            return self._unavailable(gate, "processes")
+        from ..gate import Ok
+        out = []
+        for row in rows:
+            exe = row.get("ExecutablePath")
+            if not exe:
+                continue
+            try:
+                argv = tuple(shlex.split(row.get("CommandLine") or "", posix=False))
+            except ValueError:
+                argv = ()
+            out.append(Process(int(row.get("ProcessId") or 0), str(exe), argv,
+                               int(row.get("ParentProcessId") or 0)))
+        return Ok(tuple(out))
+
+    def sockets(self, gate):
+        rows = self._ps_json(gate, "Get-NetTCPConnection | Select-Object State,LocalPort,RemoteAddress,RemotePort,OwningProcess | ConvertTo-Json -Compress", "sockets")
+        if rows is None:
+            return self._unavailable(gate, "sockets")
+        from ..gate import Ok
+        states = {"Listen": "LISTEN", "Established": "ESTABLISHED"}
+        return Ok(tuple(Socket("tcp", states[str(r.get("State"))], int(r.get("LocalPort") or 0),
+                               str(r.get("RemoteAddress") or ""), int(r.get("RemotePort") or 0),
+                               int(r.get("OwningProcess") or 0))
+                        for r in rows if str(r.get("State")) in states))
+
+    def applications(self, gate):
+        script = (
+            "$u=@(); $p=@('HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*',"
+            "'HKLM:\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*',"
+            "'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*'); "
+            "$u+=Get-ItemProperty $p -ErrorAction SilentlyContinue | Where-Object DisplayName | Select-Object @{n='Id';e={$_.PSChildName}},@{n='Name';e={$_.DisplayName}},@{n='Version';e={$_.DisplayVersion}},@{n='Vendor';e={$_.Publisher}},@{n='Path';e={$_.InstallLocation}}; "
+            "$u+=Get-AppxPackage | Select-Object @{n='Id';e={$_.PackageFamilyName}},@{n='Name';e={$_.Name}},@{n='Version';e={[string]$_.Version}},@{n='Vendor';e={$_.Publisher}},@{n='Path';e={$_.InstallLocation}}; $u|ConvertTo-Json -Compress"
+        )
+        rows = self._ps_json(gate, script, "applications")
+        if rows is None:
+            return self._unavailable(gate, "applications")
+        from ..gate import Ok
+        return Ok(tuple(Application(str(r.get("Id") or r.get("Name") or ""), str(r.get("Name") or ""),
+                                    _text(r.get("Version")), _text(r.get("Vendor")), _text(r.get("Path")))
+                        for r in rows))
+
+    def packages(self, gate):
+        apps = self.applications(gate)
+        if not apps.ok:
+            return apps
+        from ..gate import Ok
+        return Ok(tuple(Package("windows", a.ident, a.version, a.path) for a in apps.value))
+
+    def package_owner(self, gate, path):
+        from ..gate import Ok, Refused
+        apps = self.applications(gate)
+        if not apps.ok:
+            return apps
+        folded = path.casefold()
+        for app in apps.value:
+            if app.path and folded.startswith(app.path.casefold().rstrip("\\/") + "\\"):
+                return Ok(Package("windows", app.ident, app.version, app.path))
+        return Refused("not_owned", path)
+
+    def _ps_json(self, gate, script, surface):
+        ran = gate.run(("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script))
+        if not ran.ok or ran.value.code != 0:
+            return None
+        try:
+            value = json.loads(ran.value.stdout or "[]")
+        except ValueError as exc:
+            gate.ledger.probe(surface, "degraded", f"invalid PowerShell JSON: {exc}")
+            return None
+        return value if isinstance(value, list) else [value]
+
+
+def _text(value):
+    return str(value) if value not in (None, "") else None


### PR DESCRIPTION
Adds budgeted and contained host access with fixture, macOS, Linux, and Windows providers.\n\nStack: 5/14. Depends on discovery-catalog.\n\nValidation at stack tip: 218 tests passed; Ruff passed.