### PR TITLE
feat(discovery): add declaration extraction

### DIFF
--- a/Discovery/adr_discovery/extractor/__init__.py
+++ b/Discovery/adr_discovery/extractor/__init__.py
@@ -1,0 +1,270 @@
+"""M3 -- turns a located surface into declarations.
+
+The least glamorous module, and the one where hostile or merely sloppy
+input does the most damage. Two things are true of every return value: one
+malformed record never removes its valid siblings, and the count reported
+is the count that was in the file.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ..contracts.records import Candidate, Declaration, ExtractError, Extraction, Kind
+from ..redact import rules as redact
+from .formats import format_for, parse_bytes
+from .formats.workflow import agent_steps, env_names_of
+from .isolate import as_args, as_env, as_text, per_record
+from .surfaces import SURFACE_NAMES, extract_surface, surface_for
+
+__all__ = ["extract", "SCOPES", "SURFACE_NAMES"]
+
+#: Every settings scope a host application actually loads. Reading two of
+#: four and reporting the result as a count is how the hooks probe returned
+#: eight of twenty-eight.
+SCOPES: tuple[tuple[str, str], ...] = (
+    ("user", "settings.json"),
+    ("project", ".mcp.json"),
+    ("project_local", "settings.local.json"),
+    ("plugin", "mcp.json"),
+)
+
+#: Declarations are capped per surface; a cap that fires reports the true count.
+RECORD_CAP = 500
+
+
+def extract(gate, candidate: Candidate) -> Extraction:
+    """Read one surface and emit the declarations inside it.
+
+    Two shapes of surface reach this function: a config *file* holding
+    records, and a *directory* whose members are the records. They share
+    the isolation rule and the true-count rule; only the reader differs.
+    """
+    if candidate.kind == "instruction_file":
+        return Extraction(
+            declarations=(Declaration(
+                kind=Kind.INSTRUCTIONS,
+                name=candidate.path.rsplit("/", 1)[-1],
+                path=candidate.path,
+                scope=_scope_of(candidate.path),
+                raw={"surface": Kind.INSTRUCTIONS.value},
+            ),),
+            declared=1,
+        )
+
+    if candidate.kind == "shell_profile":
+        return _shell_profile(gate, candidate.path)
+
+    if surface_for(candidate.path) is not None:
+        directory = extract_surface(gate, candidate, _scope_of(candidate.path))
+        if directory is not None:
+            if directory.truncated:
+                gate.ledger.truncate(candidate.path, len(directory.declarations), directory.declared)
+            return directory
+        return Extraction(declared=0)
+
+    fmt = format_for(candidate.path)
+    if fmt is None:
+        return Extraction(declared=0)
+
+    raw = gate.read_bytes(candidate.path)
+    if not raw.ok:
+        return Extraction(errors=(ExtractError(candidate.path, None, raw.reason),), declared=0)
+
+    try:
+        document = parse_bytes(raw.value, fmt)
+    except Exception as exc:
+        if "/.mcpb/" in candidate.path and candidate.path.endswith("/manifest.json"):
+            return Extraction(
+                declarations=(Declaration(
+                    kind=Kind.MCP_BUNDLE,
+                    name=candidate.path.rstrip("/").rsplit("/", 2)[-2],
+                    path=candidate.path,
+                    scope=_scope_of(candidate.path),
+                    raw={"flags": ("malformed",), "surface": Kind.MCP_BUNDLE.value},
+                ),),
+                errors=(ExtractError(candidate.path, None, f"{type(exc).__name__}: {exc}"),),
+                declared=1,
+            )
+        gate.ledger.probe("extractor", "degraded", f"{candidate.path}: {type(exc).__name__}")
+        return Extraction(
+            errors=(ExtractError(candidate.path, None, f"{type(exc).__name__}: {exc}"),),
+            declared=0,
+        )
+
+    if not isinstance(document, dict):
+        return Extraction(
+            errors=(ExtractError(candidate.path, None, "document root is not a mapping"),),
+            declared=0,
+        )
+
+    scope = _scope_of(candidate.path)
+
+    if fmt == "workflow":
+        return _workflow(document, candidate.path)
+
+    servers = _server_block(document)
+    chunks: list[Extraction] = []
+    if servers:
+        records = list(servers.items())
+        chunks.append(per_record(
+            records,
+            lambda i, rec: _server(rec, candidate.path, scope),
+            candidate.path,
+            cap=RECORD_CAP,
+        ))
+
+    hooks = list(_hook_records(document))
+    if hooks:
+        chunks.append(per_record(
+            hooks,
+            lambda i, rec: _hook(rec, candidate.path, scope, i),
+            candidate.path,
+            cap=RECORD_CAP,
+        ))
+
+    if not chunks:
+        return Extraction(declared=0)
+
+    result = Extraction(
+        declarations=tuple(d for chunk in chunks for d in chunk.declarations),
+        errors=tuple(e for chunk in chunks for e in chunk.errors),
+        declared=sum(chunk.declared for chunk in chunks),
+        truncated=any(chunk.truncated for chunk in chunks),
+    )
+
+    if result.truncated:
+        gate.ledger.truncate(candidate.path, len(result.declarations), result.declared)
+    return result
+
+
+def _hook_records(document: dict):
+    """Yield each executable hook independently, preserving its event."""
+    block = document.get("hooks")
+    if not isinstance(block, dict):
+        return
+    for event, matchers in block.items():
+        if not isinstance(matchers, list):
+            continue
+        for matcher in matchers:
+            if not isinstance(matcher, dict):
+                continue
+            nested = matcher.get("hooks")
+            if not isinstance(nested, list):
+                continue
+            for hook in nested:
+                if isinstance(hook, dict) and hook.get("type") == "command" and hook.get("command"):
+                    yield str(event), hook
+
+
+def _hook(record, path: str, scope: str, index: int) -> Declaration:
+    event, body = record
+    command = as_text(body.get("command"), "command")
+    scrubbed = redact.scrub_argv((command,))[0]
+    return Declaration(
+        kind=Kind.HOOK,
+        name=f"{event} hook {index + 1}",
+        path=path,
+        scope=scope,
+        command=scrubbed,
+        raw={"event": event, "surface": Kind.HOOK.value},
+    )
+
+
+_EXPORT = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=")
+
+
+def _shell_profile(gate, path: str) -> Extraction:
+    """Collect only AI credential variable names, never profile values."""
+    raw = gate.read_text(path, limit=256 * 1024)
+    if not raw.ok:
+        return Extraction(errors=(ExtractError(path, None, raw.reason),), declared=0)
+    names = []
+    for line in raw.value.splitlines():
+        match = _EXPORT.match(line)
+        if match and redact.credential_kinds((match.group(1),)):
+            names.append(match.group(1))
+    if not names:
+        return Extraction(declared=0)
+    return Extraction(
+        declarations=(Declaration(
+            kind=Kind.AGENT_PLATFORM,
+            name="AI credential environment",
+            path=path,
+            scope="user",
+            env_names=tuple(sorted(set(names))),
+            raw={"surface": "shell_profile", "env_names": tuple(sorted(set(names)))},
+        ),),
+        declared=1,
+    )
+
+
+def _workflow(document: dict, path: str) -> Extraction:
+    """An agent arranged to run with no person present."""
+    steps = list(agent_steps(document))
+    return per_record(
+        steps,
+        lambda index, record: _ci_agent(record, path),
+        path,
+        cap=RECORD_CAP,
+    )
+
+
+def _ci_agent(record, path: str) -> Declaration:
+    job_name, step, reference, catalog_id = record
+    return Declaration(
+        kind=Kind.CI_AGENT,
+        name=f"{reference} ({job_name})",
+        path=path,
+        scope="ci",
+        command=reference,
+        env_names=env_names_of(step),
+        raw={"catalog_id": catalog_id, "job": job_name, "unattended": True,
+             "transport": "ci"},
+    )
+
+
+def _server_block(document: dict) -> dict:
+    """MCP servers live under different keys in different host apps."""
+    for key in ("mcpServers", "mcp_servers", "servers", "mcp"):
+        block = document.get(key)
+        if isinstance(block, dict):
+            inner = block.get("servers")
+            return inner if isinstance(inner, dict) else block
+    return {}
+
+
+def _server(record: tuple[str, object], path: str, scope: str) -> Declaration:
+    name, body = record
+    if not isinstance(body, dict):
+        raise TypeError(f"server {name!r} must be a mapping, got {type(body).__name__}")
+
+    args = as_args(body.get("args"))
+    env = as_env(body.get("env"))
+    url = body.get("url")
+
+    return Declaration(
+        kind=Kind.MCP_SERVER,
+        name=str(name),
+        path=path,
+        scope=scope,
+        command=as_text(body["command"], "command") if "command" in body else None,
+        args=redact.scrub_argv(args),
+        env_names=redact.env_names(env),
+        url=redact.strip_url(as_text(url, "url")) if url is not None else None,
+        raw={"transport": body.get("type") or ("http" if url else "stdio")},
+    )
+
+
+def _scope_of(path: str) -> str:
+    name = path.rsplit("/", 1)[-1]
+    for scope, filename in SCOPES:
+        if name == filename:
+            return scope
+    if path.startswith(("/etc/", "/Library/Application Support/ADR/", "/Library/Application Support/ClaudeCode/")):
+        return "enterprise_managed"
+    if "/plugins/" in path or "/plugin/" in path:
+        return "plugin"
+    if "/Library/" in path or "/.config/" in path or path.count("/") <= 3:
+        return "user"
+    return "project"

--- a/Discovery/adr_discovery/extractor/formats/__init__.py
+++ b/Discovery/adr_discovery/extractor/formats/__init__.py
@@ -1,0 +1,49 @@
+"""Real parsers, always.
+
+Every defect in the last two review rounds that reached production
+behaviour came from hand-rolled parsing of structured input: TOML split on
+punctuation, flags split on the first separator, image references split on
+a colon, URLs split before the port. Each function below hands the bytes to
+a parser that understands the grammar.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import plistlib as _plistlib
+import tomllib as _tomllib
+
+from . import yaml as _yaml
+
+Unrepresentable = _yaml.Unrepresentable
+
+
+def parse(text: str, fmt: str) -> dict:
+    if fmt == "json":
+        return _json.loads(text)
+    if fmt == "toml":
+        return _tomllib.loads(text)
+    if fmt in ("yaml", "yml", "workflow"):
+        return _yaml.loads(text)
+    raise ValueError(f"no parser for format {fmt!r}")
+
+
+def parse_bytes(data: bytes, fmt: str) -> dict:
+    if fmt == "plist":
+        return _plistlib.loads(data)
+    return parse(data.decode("utf-8", errors="replace"), fmt)
+
+
+def format_for(path: str) -> str | None:
+    lowered = path.lower()
+    if lowered.endswith(".json") or lowered.endswith(".jsonc"):
+        return "json"
+    if lowered.endswith(".toml"):
+        return "toml"
+    if lowered.endswith(".plist"):
+        return "plist"
+    if "/.github/workflows/" in lowered and (lowered.endswith(".yml") or lowered.endswith(".yaml")):
+        return "workflow"
+    if lowered.endswith(".yaml") or lowered.endswith(".yml"):
+        return "yaml"
+    return None

--- a/Discovery/adr_discovery/extractor/formats/frontmatter.py
+++ b/Discovery/adr_discovery/extractor/formats/frontmatter.py
@@ -1,0 +1,51 @@
+"""YAML frontmatter, read under an allowlist.
+
+A skill file is two things stacked: a small block of operational metadata,
+and a body of prose that tells an agent what to do. The body is business
+context and C2 forbids reading it, so this parser stops at the closing
+delimiter and never returns what follows.
+
+The key allowlist is the second half of the same rule. `description` is
+deliberately absent: it is the field most likely to describe what a team
+does, and knowing a skill exists and what it is permitted to touch is the
+whole of what an inventory needs.
+"""
+
+from __future__ import annotations
+
+from .yaml import Unrepresentable, loads
+
+DELIMITER = "---"
+MAX_FRONTMATTER_LINES = 60
+
+#: Operational metadata only. Anything not named here is not read.
+ALLOWED_KEYS: frozenset[str] = frozenset(
+    {"name", "model", "allowed-tools", "allowed_tools", "tools",
+     "disable-model-invocation", "argument-hint", "version", "kind"}
+)
+
+
+class NoFrontmatter(ValueError):
+    """The file does not open with a frontmatter block."""
+
+
+def parse(text: str) -> dict:
+    """Return the allowlisted keys, and nothing else.
+
+    Raises rather than guessing, so a file whose frontmatter cannot be
+    represented becomes a recorded error instead of a wrong value.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != DELIMITER:
+        raise NoFrontmatter("file does not open with a frontmatter delimiter")
+
+    block: list[str] = []
+    for line in lines[1 : MAX_FRONTMATTER_LINES + 1]:
+        if line.strip() == DELIMITER:
+            document = loads("\n".join(block))
+            return {k: v for k, v in document.items() if k in ALLOWED_KEYS}
+        block.append(line)
+
+    raise Unrepresentable(
+        f"frontmatter not closed within {MAX_FRONTMATTER_LINES} lines"
+    )

--- a/Discovery/adr_discovery/extractor/formats/workflow.py
+++ b/Discovery/adr_discovery/extractor/formats/workflow.py
@@ -1,0 +1,73 @@
+"""CI workflows, read for the agents they run.
+
+A workflow is not an asset. What matters is that a repository is arranged
+to run an agent with no person present -- which is the AI-agents target,
+and is invisible to every other source because nothing about it exists on
+the endpoint except a YAML file in a directory nobody scans for binaries.
+
+Only the step's action reference and its declared environment names are
+read. Nothing here reads a `run:` body: that is a script, out of scope by
+§1, and it is also arbitrary user text.
+"""
+
+from __future__ import annotations
+
+from ..isolate import as_env
+
+#: Action references that are an agent, not a build step. Prefix match, so
+#: a version suffix does not have to be enumerated.
+AGENT_ACTIONS: tuple[tuple[str, str], ...] = (
+    ("anthropics/claude-code-action", "claude-code"),
+    ("anthropics/claude-code-base-action", "claude-code"),
+    ("openai/codex-action", "codex-cli"),
+    ("google-github-actions/run-gemini-cli", "gemini-cli"),
+    ("github/copilot", "github-copilot"),
+    ("cursor/cursor-agent", "cursor"),
+    ("continuedev/continue-action", "continue"),
+    ("aider-ai/aider-action", "aider"),
+)
+
+
+def steps_of(document: dict):
+    """Yield (job_name, step) for every step in a workflow document."""
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        return
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if isinstance(step, dict):
+                yield str(job_name), step
+
+
+def agent_steps(document: dict):
+    """Only the steps that run an agent.
+
+    A workflow full of build steps yields nothing, which is the precision
+    half: `uses: actions/checkout@v4` is not an AI agent however many
+    agents run after it.
+    """
+    for job_name, step in steps_of(document):
+        uses = step.get("uses")
+        if not isinstance(uses, str):
+            continue
+        reference = uses.split("@", 1)[0].strip()
+        for prefix, catalog_id in AGENT_ACTIONS:
+            if reference == prefix or reference.startswith(prefix + "/"):
+                yield job_name, step, reference, catalog_id
+                break
+
+
+def env_names_of(step: dict) -> tuple[str, ...]:
+    try:
+        names = tuple(sorted(str(k) for k in as_env(step.get("env"))))
+    except TypeError:
+        names = ()
+    with_block = step.get("with")
+    if isinstance(with_block, dict):
+        names += tuple(sorted(f"with.{k}" for k in with_block))
+    return names

--- a/Discovery/adr_discovery/extractor/formats/yaml.py
+++ b/Discovery/adr_discovery/extractor/formats/yaml.py
@@ -1,0 +1,124 @@
+"""A YAML subset that refuses rather than guesses.
+
+The last hand-rolled parser standing, written to fail in the only honest
+direction: a construct outside the subset raises, so the record becomes a
+recorded error instead of a plausible wrong value. Silent mis-parsing of
+structured input produced every production defect in the last two review
+rounds, and a subset parser that guesses is precisely that engine.
+
+Supported  nested mappings by indentation, block sequences of scalars and
+           of mappings, quoted and bare scalars, booleans, integers,
+           floats, null, `#` comments
+Refused    anchors, aliases, tags, flow collections, multi-line scalars,
+           multiple documents, merge keys
+"""
+
+from __future__ import annotations
+
+REFUSED_PREFIXES = ("&", "*", "!", "<<", "---", "...")
+REFUSED_CHARS = ("{", "[")
+
+
+class Unrepresentable(ValueError):
+    """Outside the subset. Never mis-parse it instead."""
+
+
+def loads(text: str) -> dict:
+    lines: list[tuple[int, int, str]] = []
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        line = raw.split(" #", 1)[0].rstrip() if " #" in raw else raw.rstrip()
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        lines.append((lineno, len(line) - len(line.lstrip()), line.strip()))
+
+    value, consumed = _block(lines, 0, lines[0][1] if lines else 0)
+    if consumed != len(lines):
+        raise Unrepresentable(f"line {lines[consumed][0]}: indentation does not resolve")
+    return value if isinstance(value, dict) else {"": value}
+
+
+def _block(lines, i: int, indent: int):
+    """Parse every line at `indent`, returning the value and lines consumed."""
+    if i < len(lines) and lines[i][2].startswith("- "):
+        return _sequence(lines, i, indent)
+    return _mapping(lines, i, indent)
+
+
+def _sequence(lines, i: int, indent: int):
+    """Block sequence. An item is a scalar, or a mapping introduced on the
+    dash line and continued at the column just past it."""
+    out: list = []
+    while i < len(lines) and lines[i][1] == indent and lines[i][2].startswith("- "):
+        lineno, _, body = lines[i]
+        rest = body[2:].strip()
+        i += 1
+
+        if ":" not in rest:
+            out.append(_scalar(rest, lineno))
+            continue
+
+        # `- uses: x` opens a mapping whose first key sits two columns in.
+        item_indent = indent + 2
+        block = [(lineno, item_indent, rest)]
+        while i < len(lines) and lines[i][1] > indent:
+            block.append(lines[i])
+            i += 1
+        value, consumed = _mapping(block, 0, item_indent)
+        if consumed != len(block):
+            raise Unrepresentable(f"line {block[consumed][0]}: indentation does not resolve")
+        out.append(value)
+    return out, i
+
+
+def _mapping(lines, i: int, indent: int):
+    out: dict = {}
+    while i < len(lines):
+        lineno, depth, body = lines[i]
+        if depth < indent:
+            break
+        if depth > indent:
+            raise Unrepresentable(f"line {lineno}: unexpected indentation")
+        _guard(body, lineno)
+        if ":" not in body:
+            raise Unrepresentable(f"line {lineno}: not a mapping entry")
+        key, _, rest = body.partition(":")
+        key, rest = key.strip(), rest.strip()
+        i += 1
+        if rest:
+            out[key] = _scalar(rest, lineno)
+            continue
+        if i < len(lines) and lines[i][1] > indent:
+            out[key], i = _block(lines, i, lines[i][1])
+        else:
+            out[key] = None
+    return out, i
+
+
+def _guard(body: str, lineno: int) -> None:
+    if body.startswith(REFUSED_PREFIXES):
+        raise Unrepresentable(f"line {lineno}: construct outside the supported subset")
+    tail = body.split(":", 1)[-1]
+    if any(c in tail for c in REFUSED_CHARS):
+        raise Unrepresentable(f"line {lineno}: flow collection outside the supported subset")
+
+
+def _scalar(token: str, lineno: int):
+    if token.startswith(REFUSED_PREFIXES) or any(c in token for c in REFUSED_CHARS):
+        raise Unrepresentable(f"line {lineno}: scalar outside the supported subset")
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in "\"'":
+        return token[1:-1]
+    low = token.lower()
+    if low in ("true", "yes"):
+        return True
+    if low in ("false", "no"):
+        return False
+    if low in ("null", "~", ""):
+        return None
+    try:
+        return int(token)
+    except ValueError:
+        pass
+    try:
+        return float(token)
+    except ValueError:
+        return token

--- a/Discovery/adr_discovery/extractor/isolate.py
+++ b/Discovery/adr_discovery/extractor/isolate.py
@@ -1,0 +1,79 @@
+"""The per-record try boundary, written once and applied everywhere.
+
+The whole of M3's change lives here. Under per-*file* isolation one bad
+record abandons the file and four valid siblings vanish -- and the reported
+count is silently wrong, which is worse than the loss. Under per-*record*
+isolation the survivors survive, the bad one becomes an error, and the
+count reported is the count that was in the file.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Sequence
+
+from ..contracts.records import Declaration, ExtractError, Extraction
+
+
+def per_record(
+    records: Sequence[object],
+    parse_one: Callable[[int, object], Declaration],
+    path: str,
+    cap: int | None = None,
+) -> Extraction:
+    """Parse each record behind its own boundary.
+
+    `declared` is the number of records *present*, taken before parsing and
+    before the cap, so a truncated or partially-failed read still reports
+    what was really there.
+    """
+    declared = len(records)
+    window: Iterable[tuple[int, object]] = enumerate(records)
+    truncated = False
+    if cap is not None and declared > cap:
+        window = list(enumerate(records))[:cap]
+        truncated = True
+
+    good: list[Declaration] = []
+    bad: list[ExtractError] = []
+    for index, record in window:
+        try:
+            good.append(parse_one(index, record))
+        except Exception as exc:  # one record, one boundary
+            bad.append(ExtractError(path, index, f"{type(exc).__name__}: {exc}"))
+
+    return Extraction(tuple(good), tuple(bad), declared, truncated)
+
+
+# --------------------------------------------------------------- shape rules
+#
+# A string where an array belongs is one argument, not one argument per
+# character -- and it changes both the identity and the pinning verdict.
+
+
+def as_args(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        raise TypeError("args must be an array of scalars, not a string")
+    if not isinstance(value, (list, tuple)):
+        raise TypeError(f"args must be an array, got {type(value).__name__}")
+    out: list[str] = []
+    for item in value:
+        if isinstance(item, (dict, list, tuple)):
+            raise TypeError("args must contain scalars only")
+        out.append(str(item))
+    return tuple(out)
+
+
+def as_env(value: object) -> dict[str, object]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise TypeError(f"env must be a mapping, got {type(value).__name__}")
+    return value
+
+
+def as_text(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string, got {type(value).__name__}")
+    return value

--- a/Discovery/adr_discovery/extractor/surfaces.py
+++ b/Discovery/adr_discovery/extractor/surfaces.py
@@ -1,0 +1,135 @@
+"""Directory-shaped declarations.
+
+Skills, commands, agent definitions, output styles and plugins are not
+records inside a config file -- they are files in a structure a host
+application knows how to load. The unit of extraction is therefore a
+directory, and the same per-record isolation applies: one unreadable skill
+never removes its siblings, and the count reported is the count on disk.
+
+Nothing here reads a body. A skill file contributes its path, its name and
+whatever operational metadata its frontmatter declares; the prose beneath
+is business context and stays on the machine (C2).
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from ..contracts.records import Declaration, Kind
+from .formats.frontmatter import NoFrontmatter
+from .formats.frontmatter import parse as parse_frontmatter
+from .isolate import per_record
+
+#: marker directory name -> (kind, file suffix, whether the entry is a dir)
+SURFACES: tuple[tuple[str, Kind, tuple[str, ...], bool], ...] = (
+    ("skills", Kind.SKILL, (".md",), True),
+    ("commands", Kind.COMMAND, (".md", ".toml"), False),
+    ("prompts", Kind.COMMAND, (".md",), False),
+    ("agents", Kind.AGENT_DEFINITION, (".md",), False),
+    ("output-styles", Kind.OUTPUT_STYLE, (".md",), False),
+    ("plugins", Kind.PLUGIN, (".json",), True),
+)
+
+SURFACE_NAMES = frozenset(name for name, _, _, _ in SURFACES)
+ENTRY_CAP = 500
+
+
+def surface_for(path: str):
+    """Which surface, if any, this marker directory is."""
+    name = path.rstrip("/").rsplit("/", 1)[-1]
+    for surface, kind, suffixes, nested in SURFACES:
+        if name == surface:
+            return kind, suffixes, nested
+    return None
+
+
+def extract_surface(gate, candidate, scope: str):
+    """One directory of declarations."""
+    surface = surface_for(candidate.path)
+    if surface is None:
+        return None
+    kind, suffixes, nested = surface
+
+    listing = gate.list_dir(candidate.path)
+    if not listing.ok:
+        return None
+
+    entries = [e for e in listing.value if _is_member(e, suffixes, nested)]
+    return per_record(
+        entries,
+        lambda index, entry: _declaration(gate, entry, kind, scope, nested),
+        candidate.path,
+        cap=ENTRY_CAP,
+    )
+
+
+def _is_member(entry, suffixes: tuple[str, ...], nested: bool) -> bool:
+    name = entry.path.rsplit("/", 1)[-1]
+    if name.startswith("."):
+        return False
+    if nested:
+        return entry.is_dir
+    return any(name.endswith(s) for s in suffixes if s)
+
+
+#: A directory is only a member of its surface if it carries the manifest
+#: the host application loads. Without this, `~/.claude/plugins/cache` and
+#: every marketplace listing under it become "plugins" -- which is how one
+#: endpoint reported 191 assets, most of them internal bookkeeping.
+MANIFESTS = MappingProxyType({
+    Kind.SKILL: ("/SKILL.md",),
+    Kind.PLUGIN: ("/.claude-plugin/plugin.json", "/plugin.json"),
+})
+
+
+def _declaration(gate, entry, kind: Kind, scope: str, nested: bool) -> Declaration:
+    name = entry.path.rsplit("/", 1)[-1]
+    body_path = entry.path
+
+    if nested:
+        body_path = _manifest_of(gate, entry.path, kind, name)
+
+    metadata: dict[str, object] = {}
+    if body_path.endswith(".md"):
+        raw = gate.read_text(body_path, limit=64 * 1024)
+        if raw.ok:
+            try:
+                metadata = parse_frontmatter(raw.value)
+            except NoFrontmatter:
+                metadata = {}
+
+    declared_name = str(metadata.get("name") or name.removesuffix(".md"))
+    tools = metadata.get("allowed-tools") or metadata.get("allowed_tools") or metadata.get("tools")
+
+    return Declaration(
+        kind=kind,
+        name=declared_name,
+        path=entry.path,
+        scope=scope,
+        raw={
+            "surface": kind.value,
+            # What it is permitted to touch, which is the whole reason a
+            # skill is inventory and not documentation.
+            "allowed_tools": _as_tuple(tools),
+            "model": metadata.get("model"),
+        },
+    )
+
+
+def _manifest_of(gate, path: str, kind: Kind, name: str) -> str:
+    for suffix in MANIFESTS.get(kind, ()):
+        if gate.stat(path + suffix).ok:
+            return path + suffix
+    raise FileNotFoundError(
+        f"{name}: no {' or '.join(MANIFESTS.get(kind, ('manifest',)))} -- not a {kind.value}"
+    )
+
+
+def _as_tuple(value) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return tuple(part.strip() for part in value.split(",") if part.strip())
+    if isinstance(value, (list, tuple)):
+        return tuple(str(v) for v in value)
+    return ()


### PR DESCRIPTION
Adds isolated extraction for MCP configs, workflows, skills, commands, plugins, hooks, instructions, and agent definitions.\n\nStack: 7/14. Depends on discovery-enumerator.\n\nValidation at stack tip: 218 tests passed; Ruff passed.