### PR TITLE
feat(discovery): add asset resolution

### DIFF
--- a/Discovery/adr_discovery/resolver/__init__.py
+++ b/Discovery/adr_discovery/resolver/__init__.py
@@ -1,0 +1,159 @@
+"""M5 -- one real thing becomes exactly one asset.
+
+The count is the product, and both ways of getting it wrong are invisible
+from the inside: a false split inflates the inventory, a false merge hides
+a tool, and each produces a plausible-looking answer.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from ..contracts.records import Asset, Liveness, Observation, Risk
+from .confidence import band_for
+from .keys import asset_id, identity_of, normalize_root
+from .merge import group
+
+__all__ = ["resolve", "asset_id", "normalize_root"]
+
+#: Strongest liveness wins when observations of one install disagree: a
+#: process is proof the thing runs, whatever the config says.
+_LIVENESS_RANK = MappingProxyType(
+    {Liveness.RUNNING: 2, Liveness.INSTALLED: 1, Liveness.DECLARED_ONLY: 0}
+)
+
+
+def resolve(observations: tuple[Observation, ...], telemetry: dict[str, str] | None = None,
+            ledger=None) -> tuple[Asset, ...]:
+    """Merge observations into assets, derive confidence, decide liveness."""
+    if not observations:
+        return ()
+
+    observations = bind_contained(observations)
+    groups, refused = group(observations)
+    if ledger is not None and refused:
+        ledger.probe("resolver", "ran", f"{refused} bridging merge(s) refused")
+
+    assets: list[Asset] = []
+    for members in groups:
+        rows = [observations[i] for i in members]
+        primary = _primary(rows)
+
+        evidence = tuple(e for row in rows for e in row.evidence)
+        liveness = max((r.liveness for r in rows), key=_LIVENESS_RANK.__getitem__)
+        install_root = next((r.install_root for r in rows if r.install_root), None)
+        identity = identity_of(primary)
+        owner = next((r.owner for r in rows if r.owner), "system")
+
+        rungs = tuple(sorted({e.rung for e in evidence if e.rung is not None},
+                             key=lambda r: r.value))
+        last_used = (telemetry or {}).get(primary.catalog_id or identity)
+
+        assets.append(
+            Asset(
+                asset_id=asset_id(primary.kind.value, identity, owner, install_root),
+                kind=primary.kind,
+                name=primary.detail.get("name") or identity,
+                identity=identity,
+                catalog_id=primary.catalog_id,
+                vendor=primary.detail.get("vendor"),
+                version=next((r.version for r in rows if r.version), None),
+                install_path=primary.path,
+                install_root=install_root,
+                install_method=primary.detail.get("install_method"),
+                owner=owner,
+                location=primary.detail.get("location", "local"),
+                liveness=liveness,
+                last_used=last_used,
+                confidence=band_for(evidence),
+                verification=rungs,
+                evidence=evidence,
+                risk=_runtime_risk(rows),
+                flags=_flags(rows),
+            )
+        )
+    return tuple(assets)
+
+
+def bind_contained(observations: tuple[Observation, ...]) -> tuple[Observation, ...]:
+    """An observation that lives inside another install describes it.
+
+    A package directory and the `bin` symlink pointing into it are one
+    install reached two ways. Neither shares a content hash (one is a
+    directory), an inode, or a normalized root -- so without this pass they
+    are two assets that agree about everything, which is the false split in
+    its most ordinary form.
+
+    Containment is only allowed to bind observations whose catalogued
+    identities do not disagree; the group rule in `merge` still has the
+    final say.
+    """
+    from dataclasses import replace
+
+    roots = [
+        (obs.path.rstrip("/"), obs)
+        for obs in observations
+        if obs.path and not obs.attribute_of
+    ]
+    roots.sort(key=lambda pair: len(pair[0]), reverse=True)
+
+    bound: list[Observation] = []
+    for obs in observations:
+        if obs.attribute_of or not obs.path:
+            bound.append(obs)
+            continue
+        inside = _containing(obs, roots)
+        bound.append(replace(obs, attribute_of=inside) if inside else obs)
+    return tuple(bound)
+
+
+def _containing(obs: Observation, roots) -> str | None:
+    probes = [p for p in (obs.real_path, obs.path) if p]
+    for root, other in roots:
+        if other is obs or not root:
+            continue
+        if obs.catalog_id and other.catalog_id and obs.catalog_id != other.catalog_id:
+            continue
+        if any(probe.startswith(root + "/") for probe in probes):
+            return other.path
+    return None
+
+
+def _primary(rows: list[Observation]) -> Observation:
+    """The observation that best describes the install itself.
+
+    An attribute -- a model directory, a state folder -- describes something
+    about an install and must never become the row the asset is named from.
+    """
+    real = [r for r in rows if not r.attribute_of]
+    pool = real or rows
+    return max(pool, key=lambda r: (bool(r.catalog_id), bool(r.content_hash), bool(r.path)))
+
+
+def _flags(rows: list[Observation]) -> tuple[str, ...]:
+    flags: set[str] = set()
+    if all(r.attribute_of for r in rows):
+        flags.add("state_only")
+    if any(r.detail.get("alias") for r in rows):
+        flags.add("alias")
+    if len(rows) > 1:
+        flags.add(f"merged_{len(rows)}")
+    for row in rows:
+        flags.update(str(flag) for flag in (row.detail.get("flags") or ()))
+        scope = row.detail.get("scope")
+        if scope:
+            flags.add(f"config_scope={scope}")
+    return tuple(sorted(flags))
+
+
+def _runtime_risk(rows: list[Observation]) -> Risk:
+    """Carry derived live-process facts, never raw argv or environment values."""
+    env_names = tuple(sorted({
+        str(name)
+        for row in rows
+        for name in (row.detail.get("env_names") or ())
+    }))
+    return Risk(
+        env_names=env_names,
+        unattended=any(bool(row.detail.get("unattended")) for row in rows),
+    )

--- a/Discovery/adr_discovery/resolver/confidence.py
+++ b/Discovery/adr_discovery/resolver/confidence.py
@@ -1,0 +1,19 @@
+"""Confidence counts independent channels, never repeated observations.
+
+A binary and the symlink pointing at it are one FILESYSTEM sighting of one
+fact. Multiplying their confidences manufactures certainty out of a single
+look, which is how an inventory becomes confidently wrong.
+"""
+
+from __future__ import annotations
+
+from ..contracts.evidence import Band, Channel, Evidence
+
+
+def band_for(evidence: tuple[Evidence, ...]) -> Band:
+    """Distinct channels only -- repetition inside one channel adds nothing."""
+    return Band.from_channels([e.channel for e in evidence])
+
+
+def independent_channels(evidence: tuple[Evidence, ...]) -> tuple[Channel, ...]:
+    return tuple(sorted({e.channel for e in evidence}, key=lambda c: c.value))

--- a/Discovery/adr_discovery/resolver/keys.py
+++ b/Discovery/adr_discovery/resolver/keys.py
@@ -1,0 +1,93 @@
+"""Merge keys, strongest first.
+
+    content hash          same bytes, wherever they sit
+  > real path / inode     same file, reached by any number of links
+  > package identity      same package record
+  > signature identity    same publisher and product
+  > catalog + owner + normalized install root
+
+The first line is the addition. Ollama was counted twice because the
+model-directory observation had no path to merge on and the binary
+observation did -- two rows, one identity, disagreeing about version and
+liveness. An observation that describes an *attribute* of an install binds
+to the install rather than standing alone.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+from ..contracts.records import Observation
+
+#: Content-addressed store paths carry a build hash that changes on every
+#: rebuild without the install changing. Normalizing it is what lets
+#: `asset_id` survive a store rebuild (U5-11).
+_STORE_PATTERNS = (
+    re.compile(r"^(/nix/store)/[a-z0-9]{32}-(.+?)(/.*)?$"),
+    re.compile(r"^(/gnu/store)/[a-z0-9]{32}-(.+?)(/.*)?$"),
+    re.compile(r"^(.*/\.pnpm)/[^/]+@[^/]+(/.*)?$"),
+)
+
+
+def normalize_root(path: str | None) -> str | None:
+    if not path:
+        return path
+    for pattern in _STORE_PATTERNS:
+        m = pattern.match(path)
+        if m:
+            return f"{m.group(1)}/*-{m.group(2)}"
+    return path
+
+
+def keys_for(obs: Observation) -> tuple[tuple[str, str], ...]:
+    """Every key this observation can be merged on, strongest first."""
+    out: list[tuple[str, str]] = []
+    if obs.content_hash:
+        out.append(("content", obs.content_hash))
+    if obs.real_path:
+        out.append(("realpath", obs.real_path))
+    if obs.inode:
+        out.append(("inode", obs.inode))
+    if obs.package_id:
+        out.append(("package", obs.package_id))
+    if obs.signature_id:
+        out.append(("signature", obs.signature_id))
+    if obs.catalog_id:
+        root = normalize_root(obs.install_root) or ""
+        out.append(("catalog", f"{obs.catalog_id}|{obs.owner or 'system'}|{root}"))
+    else:
+        # Uncatalogued things still have an identity. Without this key a
+        # server declared in two scopes becomes two assets -- a false split
+        # that looks exactly like two servers.
+        out.append(("identity", f"{obs.kind.value}|{obs.identity}|{obs.owner or 'system'}"))
+    # An attribute binds to *its* install and never stands alone, so both
+    # sides of the binding have to emit the same key. Keying on the
+    # parent's path rather than its identity is what keeps two installs of
+    # one tool -- a release and a vendored alpha -- from collapsing into one.
+    if obs.attribute_of:
+        out.append(("install", obs.attribute_of))
+    elif obs.path:
+        out.append(("install", obs.path))
+    return tuple(out)
+
+
+def identity_of(obs: Observation) -> str:
+    """What must stay singular within a merged group.
+
+    Two observations that name different tools may never merge, however
+    many weak keys they happen to share.
+    """
+    return obs.catalog_id or obs.identity
+
+
+def asset_id(kind: str, identity: str, owner: str, install_root: str | None) -> str:
+    """Stable across benign change.
+
+    Deliberately excludes the version (an upgrade is not a new asset), any
+    credential material (a rotation is not a new asset), and the build hash
+    inside a content-addressed store path (a rebuild is not a new asset).
+    """
+    root = normalize_root(install_root) or ""
+    payload = f"{kind}\0{identity}\0{owner}\0{root}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]

--- a/Discovery/adr_discovery/resolver/merge.py
+++ b/Discovery/adr_discovery/resolver/merge.py
@@ -1,0 +1,75 @@
+"""Group formation, and the refusal to bridge two identities.
+
+Checking conflict pairwise is not enough. A bridging observation shares a
+key with each of two unrelated tools, passes both pairwise checks, and
+transitivity then unites them -- one tool silently disappears, and the
+count, which is the product, is wrong in the direction nobody notices.
+
+So conflict is evaluated on the *group*: a merge is applied only if the
+union's identity set stays singular.
+"""
+
+from __future__ import annotations
+
+from ..contracts.records import Observation
+from .keys import identity_of, keys_for
+
+
+class _Groups:
+    """Union-find, with the union guarded by the group identity rule."""
+
+    def __init__(self, n: int) -> None:
+        self.parent = list(range(n))
+        self.identities: list[set[str]] = [set() for _ in range(n)]
+
+    def find(self, i: int) -> int:
+        while self.parent[i] != i:
+            self.parent[i] = self.parent[self.parent[i]]
+            i = self.parent[i]
+        return i
+
+    def union(self, a: int, b: int) -> bool:
+        ra, rb = self.find(a), self.find(b)
+        if ra == rb:
+            return True
+        merged = self.identities[ra] | self.identities[rb]
+        if len(merged) > 1:
+            return False  # would make the group's identity plural
+        self.parent[rb] = ra
+        self.identities[ra] = merged
+        return True
+
+
+def group(observations: tuple[Observation, ...]) -> tuple[tuple[int, ...], ...]:
+    """Return index groups. Order within a group follows input order."""
+    groups = _Groups(len(observations))
+    for i, obs in enumerate(observations):
+        ident = identity_of(obs)
+        if ident:
+            groups.identities[i].add(ident)
+
+    # Strongest key kind first, so a strong merge is applied before a weak
+    # one can be refused for a conflict the strong merge would have settled.
+    by_kind: dict[str, dict[str, list[int]]] = {}
+    for i, obs in enumerate(observations):
+        for kind, value in keys_for(obs):
+            by_kind.setdefault(kind, {}).setdefault(value, []).append(i)
+
+    refused = 0
+    for kind in ("content", "realpath", "inode", "package", "signature",
+                 "install", "catalog", "identity"):
+        for members in by_kind.get(kind, {}).values():
+            anchor = members[0]
+            for other in members[1:]:
+                if not groups.union(anchor, other):
+                    refused += 1
+
+    buckets: dict[int, list[int]] = {}
+    for i in range(len(observations)):
+        buckets.setdefault(groups.find(i), []).append(i)
+    return tuple(tuple(v) for v in buckets.values()), refused
+
+
+def group_only(observations: tuple[Observation, ...]) -> tuple[tuple[int, ...], ...]:
+    grouped, _ = group(observations)
+    return grouped


### PR DESCRIPTION
Adds conflict-safe observation grouping, stable asset identity, confidence, liveness, and telemetry binding.\n\nStack: 9/14. Depends on discovery-identifier.\n\nValidation at stack tip: 218 tests passed; Ruff passed.