### PR TITLE
feat(discovery): add snapshot reporting

### DIFF
--- a/Discovery/adr_discovery/reporter/__init__.py
+++ b/Discovery/adr_discovery/reporter/__init__.py
@@ -1,0 +1,8 @@
+"""M7 -- the snapshot, and the difference between this one and the last."""
+
+from __future__ import annotations
+
+from .delta import Delta, DifferentEndpoints, diff
+from .snapshot import from_dict, stats, to_dict, to_json
+
+__all__ = ["diff", "Delta", "DifferentEndpoints", "from_dict", "to_dict", "to_json", "stats"]

--- a/Discovery/adr_discovery/reporter/delta.py
+++ b/Discovery/adr_discovery/reporter/delta.py
@@ -1,0 +1,120 @@
+"""What the delta says.
+
+    appeared · disappeared · version_changed · config_changed · reinstalled
+  + risk_delta       pinned -> floating is a silent regression otherwise
+  + coverage_delta   a surface that became unreadable is a change too
+
+Fleet fan-out -- the same new asset landing on many endpoints at once -- is
+computable only centrally and is deliberately absent from this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..contracts.snapshot import Snapshot
+from .identity import by_id, by_identity
+
+
+class DifferentEndpoints(ValueError):
+    """A diff compares one endpoint with itself unless told otherwise.
+
+    Diffing two machines produces a fictional delta in which every asset on
+    each looks like a change, and nothing in the output says so.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class Change:
+    kind: str
+    asset_id: str
+    name: str
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class Delta:
+    endpoint: str
+    changes: tuple[Change, ...] = ()
+    coverage_delta: tuple[str, ...] = ()
+
+    def of(self, kind: str) -> tuple[Change, ...]:
+        return tuple(c for c in self.changes if c.kind == kind)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.changes and not self.coverage_delta
+
+
+def diff(before: Snapshot, after: Snapshot, allow_cross_endpoint: bool = False) -> Delta:
+    if before.hostname != after.hostname and not allow_cross_endpoint:
+        raise DifferentEndpoints(
+            f"refusing to diff {before.hostname!r} against {after.hostname!r}; "
+            "pass allow_cross_endpoint=True if that is genuinely what you want"
+        )
+
+    old_by_id, new_by_id = by_id(before.assets), by_id(after.assets)
+    old_by_identity, new_by_identity = by_identity(before.assets), by_identity(after.assets)
+    changes: list[Change] = []
+
+    for asset_id, new in new_by_id.items():
+        old = old_by_id.get(asset_id)
+        if old is None:
+            key = (new.kind.value, new.identity, new.owner)
+            previous = old_by_identity.get(key)
+            if previous is not None and previous.asset_id not in new_by_id:
+                changes.append(
+                    Change("reinstalled", new.asset_id, new.name,
+                           f"{previous.install_root} -> {new.install_root}")
+                )
+            else:
+                changes.append(Change("appeared", new.asset_id, new.name))
+            continue
+
+        if old.version != new.version:
+            changes.append(
+                Change("version_changed", asset_id, new.name, f"{old.version} -> {new.version}")
+            )
+        if _config_of(old) != _config_of(new):
+            changes.append(Change("config_changed", asset_id, new.name))
+        # An asset set that did not move can still carry a regression.
+        if old.risk.pinned is True and new.risk.pinned is False:
+            changes.append(
+                Change("risk_delta", asset_id, new.name, "pinned -> floating")
+            )
+        elif set(new.risk.factors) - set(old.risk.factors):
+            changes.append(
+                Change("risk_delta", asset_id, new.name,
+                       "+" + ",".join(sorted(set(new.risk.factors) - set(old.risk.factors))))
+            )
+
+    for asset_id, old in old_by_id.items():
+        if asset_id in new_by_id:
+            continue
+        key = (old.kind.value, old.identity, old.owner)
+        if key in new_by_identity and new_by_identity[key].asset_id not in old_by_id:
+            continue  # already reported as a reinstall
+        changes.append(Change("disappeared", asset_id, old.name))
+
+    return Delta(after.hostname, tuple(changes), _coverage_delta(before, after))
+
+
+def _config_of(asset) -> tuple:
+    return (asset.install_path, asset.risk.transport, tuple(sorted(asset.risk.env_names)))
+
+
+def _coverage_delta(before: Snapshot, after: Snapshot) -> tuple[str, ...]:
+    """A surface that became unreadable is a change, and a silent one."""
+    out: list[str] = []
+    old_denied = {d.path for d in before.coverage.denied}
+    new_denied = {d.path for d in after.coverage.denied}
+    for path in sorted(new_denied - old_denied):
+        out.append(f"became unreadable: {path}")
+    for path in sorted(old_denied - new_denied):
+        out.append(f"became readable: {path}")
+
+    old_gone = {u.provider for u in before.coverage.unavailable}
+    new_gone = {u.provider for u in after.coverage.unavailable}
+    for provider in sorted(new_gone - old_gone):
+        out.append(f"provider became unavailable: {provider}")
+    return tuple(out)

--- a/Discovery/adr_discovery/reporter/identity.py
+++ b/Discovery/adr_discovery/reporter/identity.py
@@ -1,0 +1,24 @@
+"""Matching assets across two snapshots.
+
+The delta depends entirely on `asset_id` holding still under change that is
+not a change. It must survive a version upgrade, a content-addressed store
+rebuild and a credential rotation -- the last of which requires that no
+secret material reach the hash, which is why the id is computed inside M5
+rather than assembled by its callers.
+
+`reinstalled` is the one case where the id legitimately moves: same
+identity and owner, different install root.
+"""
+
+from __future__ import annotations
+
+from ..contracts.records import Asset
+
+
+def by_id(assets: tuple[Asset, ...]) -> dict[str, Asset]:
+    return {a.asset_id: a for a in assets}
+
+
+def by_identity(assets: tuple[Asset, ...]) -> dict[tuple[str, str, str], Asset]:
+    """A weaker key, used only to tell a reinstall from a disappearance."""
+    return {(a.kind.value, a.identity, a.owner): a for a in assets}

--- a/Discovery/adr_discovery/reporter/snapshot.py
+++ b/Discovery/adr_discovery/reporter/snapshot.py
@@ -1,0 +1,143 @@
+"""Serialization.
+
+A snapshot is emitted even when nothing is found: to fleet coverage, a host
+that reported an empty inventory and a host that never reported are very
+different facts, and only one of them is evidence.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from enum import Enum
+
+from ..contracts.evidence import Band, Channel, Evidence, Rung
+from ..contracts.records import Asset, Finding, Kind, Liveness, ReviewItem, Risk
+from ..contracts.snapshot import (
+    SCHEMA_VERSION,
+    BoundaryHit,
+    Coverage,
+    Denied,
+    ProbeRun,
+    RootSwept,
+    Snapshot,
+    Truncated,
+    Unavailable,
+)
+
+
+def to_dict(snapshot: Snapshot) -> dict:
+    return _encode(snapshot)
+
+
+def to_json(snapshot: Snapshot, indent: int | None = 2) -> str:
+    return json.dumps(to_dict(snapshot), indent=indent, sort_keys=True)
+
+
+def _encode(value):
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {f.name: _encode(getattr(value, f.name)) for f in dataclasses.fields(value)}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {str(k): _encode(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_encode(v) for v in value]
+    return value
+
+
+def from_dict(document: dict) -> Snapshot:
+    """Rebuild a snapshot from its serialized form.
+
+    Needed because the delta is the product: comparing this scan with the
+    last one means reading the last one back, and a snapshot that can only
+    be written is a snapshot that can only be filed away.
+    """
+    return Snapshot(
+        hostname=document.get("hostname", "unknown"),
+        username=document.get("username", "unknown"),
+        platform=document.get("platform", "unknown"),
+        timestamp=document.get("timestamp", ""),
+        assets=tuple(_asset(a) for a in document.get("assets", ())),
+        findings=tuple(_finding(f) for f in document.get("findings", ())),
+        review_queue=tuple(
+            ReviewItem(path=r.get("path", ""), score=r.get("score", 0.0),
+                       signals=tuple(r.get("signals", ())))
+            for r in document.get("review_queue", ())
+        ),
+        coverage=_coverage(document.get("coverage") or {}),
+        catalog_version=document.get("catalog_version", "unknown"),
+        schema_version=document.get("schema_version", SCHEMA_VERSION),
+    )
+
+
+def _asset(row: dict) -> Asset:
+    risk = row.get("risk") or {}
+    band = row.get("confidence") or {}
+    return Asset(
+        asset_id=row["asset_id"],
+        kind=Kind(row["kind"]),
+        name=row.get("name", ""),
+        identity=row.get("identity", ""),
+        catalog_id=row.get("catalog_id"),
+        vendor=row.get("vendor"),
+        version=row.get("version"),
+        install_path=row.get("install_path"),
+        install_root=row.get("install_root"),
+        install_method=row.get("install_method"),
+        owner=row.get("owner", "system"),
+        location=row.get("location", "local"),
+        liveness=Liveness(row.get("liveness", "installed")),
+        last_used=row.get("last_used"),
+        confidence=Band(band.get("label", "none"),
+                        tuple(Channel(c) for c in band.get("channels", ()))),
+        verification=tuple(Rung(r) for r in row.get("verification", ())),
+        evidence=tuple(
+            Evidence(e.get("stage", ""), Channel(e["channel"]), e.get("path", ""),
+                     e.get("proof", ""), e.get("confidence", 0.0),
+                     Rung(e["rung"]) if e.get("rung") else None)
+            for e in row.get("evidence", ())
+        ),
+        risk=Risk(
+            pinned=risk.get("pinned"),
+            factors=tuple(risk.get("factors", ())),
+            credential_kinds=tuple(risk.get("credential_kinds", ())),
+            env_names=tuple(risk.get("env_names", ())),
+            transport=risk.get("transport"),
+            destinations=tuple(risk.get("destinations", ())),
+            unattended=risk.get("unattended", False),
+        ),
+        sanction=row.get("sanction", "unknown"),
+        flags=tuple(row.get("flags", ())),
+    )
+
+
+def _finding(row: dict) -> Finding:
+    return Finding(rule=row.get("rule", ""), severity=row.get("severity", "medium"),
+                   asset_id=row.get("asset_id", ""), summary=row.get("summary", ""))
+
+
+def _coverage(row: dict) -> Coverage:
+    return Coverage(
+        roots_swept=tuple(RootSwept(**r) for r in row.get("roots_swept", ())),
+        boundaries_hit=tuple(BoundaryHit(**b) for b in row.get("boundaries_hit", ())),
+        denied=tuple(Denied(**d) for d in row.get("denied", ())),
+        unavailable=tuple(Unavailable(**u) for u in row.get("unavailable", ())),
+        truncated=tuple(Truncated(**t) for t in row.get("truncated", ())),
+        probes=tuple(ProbeRun(**p) for p in row.get("probes", ())),
+        out_of_scope=tuple(row.get("out_of_scope", ())),
+    )
+
+
+def stats(snapshot: Snapshot) -> dict[str, int]:
+    return {
+        "asset_count": len(snapshot.assets),
+        "finding_count": len(snapshot.findings),
+        "review_queue_count": len(snapshot.review_queue),
+        "coverage_gaps": (
+            len(snapshot.coverage.denied)
+            + len(snapshot.coverage.unavailable)
+            + len(snapshot.coverage.boundaries_hit)
+            + len(snapshot.coverage.truncated)
+        ),
+    }


### PR DESCRIPTION
Adds versioned snapshot serialization, round-trip decoding, stable identity lookup, statistics, and endpoint-safe deltas.\n\nStack: 11/14. Depends on discovery-judge.\n\nValidation at stack tip: 218 tests passed; Ruff passed.