### PR TITLE
test(discovery): cover collector modules

### DIFF
--- a/Discovery/adr_discovery/tests_unit/conftest.py
+++ b/Discovery/adr_discovery/tests_unit/conftest.py
@@ -1,0 +1,113 @@
+"""Fixture worlds.
+
+A fixture directory and a live machine are interchangeable below M1, so
+every case here builds a world on disk and drives the real pipeline over
+it. Nothing is mocked; the gate reads these trees exactly as it reads `/`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from adr_discovery.catalog.load import loads as load_catalog
+from adr_discovery.coverage.ledger import Ledger
+from adr_discovery.world.budget import Budget
+from adr_discovery.world.gate import Gate
+from adr_discovery.world.platform.base import FixtureProviders
+
+PACKAGE = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+class World:
+    """A machine on disk, plus the non-filesystem surfaces beside it."""
+
+    def __init__(self, root: str) -> None:
+        self.root = root
+        self._restore: list[str] = []
+
+    def cleanup(self) -> None:
+        for path in self._restore:
+            try:
+                os.chmod(path, 0o755)
+            except OSError:
+                pass
+
+    def file(self, path: str, body: str = "") -> "World":
+        full = self.root + path
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w", encoding="utf-8") as fh:
+            fh.write(body)
+        return self
+
+    def json(self, path: str, document) -> "World":
+        return self.file(path, json.dumps(document))
+
+    def binary(self, path: str, body: str) -> "World":
+        """Exact bytes, plus the executable bit.
+
+        `exe` writes a shell wrapper of its own devising, which is fine for
+        version probes and useless for a case that asserts on a hash.
+        """
+        self.file(path, body)
+        os.chmod(self.root + path, 0o755)
+        return self
+
+    def exe(self, path: str, prints: str) -> "World":
+        self.file(path, f"#!/bin/sh\necho {prints!r}\n")
+        os.chmod(self.root + path, 0o755)
+        return self
+
+    def dir(self, path: str) -> "World":
+        os.makedirs(self.root + path, exist_ok=True)
+        return self
+
+    def unreadable(self, path: str) -> "World":
+        """Make a directory unreadable, and restore it at teardown.
+
+        Without the restore, pytest cannot clean its own tmp tree and every
+        later run inherits the mess.
+        """
+        os.chmod(self.root + path, 0o000)
+        self._restore.append(self.root + path)
+        return self
+
+    def symlink(self, path: str, target: str, outside: bool = False) -> "World":
+        """`target` is a path *inside* this world unless `outside` is set.
+
+        The distinction matters: a link out of the world is refused for
+        containment before the deny-list is ever consulted, so a case about
+        the deny-list has to stay inside.
+        """
+        full = self.root + path
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        os.symlink(target if outside else self.root + target, full)
+        return self
+
+    def surface(self, name: str, rows) -> "World":
+        """processes | sockets | packages | applications | dns | execjournal"""
+        return self.json(f"/{name}.json", rows)
+
+    def gate(self, **kwargs) -> Gate:
+        kwargs.setdefault("ledger", Ledger())
+        kwargs.setdefault("budget", Budget(max_entries=50_000))
+        kwargs.setdefault("providers", FixtureProviders())
+        kwargs.setdefault("env", {"PATH": "/usr/bin:/bin"})
+        return Gate(self.root, **kwargs)
+
+
+@pytest.fixture
+def world(tmp_path):
+    built = World(str(tmp_path))
+    try:
+        yield built
+    finally:
+        built.cleanup()
+
+
+@pytest.fixture(scope="session")
+def catalog():
+    with open(os.path.join(PACKAGE, "catalog", "catalog.json"), encoding="utf-8") as fh:
+        return load_catalog(fh.read())

--- a/Discovery/adr_discovery/tests_unit/test_ci_agents.py
+++ b/Discovery/adr_discovery/tests_unit/test_ci_agents.py
@@ -1,0 +1,83 @@
+"""CI agents -- an agent arranged to run with no person present.
+
+Invisible to every other source: nothing about it exists on the endpoint
+except a YAML file in a directory no binary scan reads.
+"""
+
+from __future__ import annotations
+
+from adr_discovery.contracts.records import Candidate, Kind
+from adr_discovery.extractor import extract
+from adr_discovery.pipeline import discover
+
+WORKFLOW = """name: review
+on:
+  pull_request:
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: secret-value-here
+        with:
+          mode: agent
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+      - uses: actions/cache@v4
+"""
+
+
+def read(world, path="/proj/.github/workflows/review.yml", body=WORKFLOW):
+    world.file(path, body)
+    return extract(world.gate(), Candidate(kind="marker_file", path=path, source="sweep"))
+
+
+def test_an_agent_step_becomes_a_declaration(world):
+    result = read(world)
+
+    (declaration,) = result.declarations
+    assert declaration.kind is Kind.CI_AGENT
+    assert declaration.raw["catalog_id"] == "claude-code"
+    assert declaration.raw["job"] == "review"
+    assert declaration.raw["unattended"] is True
+
+
+def test_build_steps_are_not_agents(world):
+    """`uses: actions/checkout@v4` is not an AI agent however many agents
+    run after it -- the precision half of this source."""
+    result = read(world)
+
+    assert len(result.declarations) == 1, "only the agent step counts"
+
+
+def test_env_names_survive_and_values_do_not(world):
+    (declaration,) = read(world).declarations
+
+    assert "ANTHROPIC_API_KEY" in declaration.env_names
+    assert "with.mode" in declaration.env_names
+    assert "secret-value-here" not in repr(declaration)
+
+
+def test_a_workflow_with_no_agent_yields_nothing(world):
+    result = read(world, body="""name: ci
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+""")
+
+    assert result.declarations == () and result.declared == 0
+
+
+def test_a_ci_agent_reaches_the_snapshot(world, catalog):
+    world.file("/Users/a/proj/.github/workflows/review.yml", WORKFLOW)
+
+    snapshot = discover(world.gate(), catalog)
+
+    agents = [a for a in snapshot.assets if a.kind is Kind.CI_AGENT]
+    assert len(agents) == 1
+    assert "claude-code-action" in agents[0].name

--- a/Discovery/adr_discovery/tests_unit/test_content_identity.py
+++ b/Discovery/adr_discovery/tests_unit/test_content_identity.py
@@ -1,0 +1,88 @@
+"""Content identity -- M4 rung 2, and M5's strongest merge key.
+
+These two live together because they are the same read: the hash that
+identifies a self-compiled build is the hash that merges a copy of it
+found somewhere else.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from adr_discovery.catalog.load import CatalogError
+from adr_discovery.catalog.load import loads as load_catalog
+from adr_discovery.contracts.evidence import Rung
+from adr_discovery.contracts.records import Candidate, Priority
+from adr_discovery.identifier import content_hash, identify
+from adr_discovery.pipeline import discover
+
+BODY = "#!/bin/sh\necho 2.1.234\n"
+DIGEST = hashlib.sha256(BODY.encode()).hexdigest()
+
+
+def catalog_with_hash(digest=DIGEST):
+    return load_catalog(json.dumps({"version": "test", "entries": [{
+        "id": "claude-code", "name": "Claude Code", "vendor": "Anthropic", "kind": "cli_agent",
+        "fingerprints": {"binaries": ["claude"]},
+        "proofs": {"content_hashes": [digest]},
+    }]}))
+
+
+def test_the_loader_indexes_content_hashes():
+    """Without this index, rung 2 is dead code that silently never fires."""
+    catalog = catalog_with_hash()
+
+    assert catalog.match("content_hashes", DIGEST).id == "claude-code"
+
+
+def test_a_hash_claimed_by_two_entries_fails_the_load():
+    document = {"entries": [
+        {"id": "a", "name": "A", "vendor": "V", "kind": "cli_agent",
+         "proofs": {"content_hashes": [DIGEST]}},
+        {"id": "b", "name": "B", "vendor": "V", "kind": "cli_agent",
+         "proofs": {"content_hashes": [DIGEST]}},
+    ]}
+
+    with pytest.raises(CatalogError, match="ambiguous"):
+        load_catalog(json.dumps(document))
+
+
+def test_content_identifies_a_build_with_no_package_record(world):
+    """A self-compiled binary under a name nobody recognises."""
+    world.binary("/opt/built/mystery-tool", BODY)
+    gate = world.gate()
+
+    verdict = identify(gate, Candidate("binary", "/opt/built/mystery-tool", "sweep",
+                                       Priority.HOME), catalog_with_hash())
+
+    assert verdict.catalog_id == "claude-code"
+    assert verdict.rung is Rung.CONTENT
+    assert verdict.is_concluded
+
+
+def test_a_partial_read_never_produces_a_hash(world):
+    """A hash of truncated bytes is worse than no hash: it is a confident
+    wrong answer that would merge two unrelated things."""
+    from adr_discovery.world.budget import Budget
+
+    world.file("/big", "x" * 5000)
+    gate = world.gate(budget=Budget(max_read_bytes=1000))
+
+    assert content_hash(gate, "/big") is None
+
+
+def test_two_copies_of_one_binary_are_one_asset(world):
+    """Same bytes, two paths, no package record and no shared inode --
+    content is the only key that can merge them."""
+    world.binary("/opt/a/claude", BODY)
+    world.binary("/opt/b/claude", BODY)
+    gate = world.gate()
+
+    snapshot = discover(gate, catalog_with_hash())
+
+    agents = [a for a in snapshot.assets if a.catalog_id == "claude-code"]
+    assert len(agents) == 1, "a copy is not a second install"
+    assert "merged_2" in agents[0].flags

--- a/Discovery/adr_discovery/tests_unit/test_cross_cutting.py
+++ b/Discovery/adr_discovery/tests_unit/test_cross_cutting.py
@@ -1,0 +1,170 @@
+"""C1 catalog · C2 redaction · C3 coverage.
+
+The three concerns that are not stages. Their cases are shaped differently:
+C1 is almost entirely about rejection at load, C2 measures both directions
+of a filter, and C3 can only be tested by planting something real and
+making it unreachable.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from adr_discovery.catalog.load import CatalogError
+from adr_discovery.catalog.load import loads as load_catalog
+from adr_discovery.contracts.snapshot import OUT_OF_SCOPE
+from adr_discovery.pipeline import discover
+from adr_discovery.redact import rules as redact
+from adr_discovery.reporter import to_json
+
+
+def entry(**kwargs):
+    base = {"id": "a", "name": "A", "vendor": "V", "kind": "cli_agent"}
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------- C1 catalog
+
+
+def test_uc1_01_an_ambiguous_fingerprint_fails_the_load():
+    document = {"entries": [
+        entry(id="a", fingerprints={"binaries": ["codex"]}),
+        entry(id="b", fingerprints={"binaries": ["codex"]}),
+    ]}
+
+    with pytest.raises(CatalogError, match="ambiguous"):
+        load_catalog(json.dumps(document))
+
+
+def test_uc1_02_a_probe_without_a_shape_is_rejected():
+    document = {"entries": [entry(proofs={"version_probe": ["--version"]})]}
+
+    with pytest.raises(CatalogError, match="version_shape"):
+        load_catalog(json.dumps(document))
+
+
+def test_uc1_03_a_bad_shape_is_rejected_at_load_not_at_match():
+    document = {"entries": [entry(proofs={"version_probe": ["-v"], "version_shape": "[unclosed"})]}
+
+    with pytest.raises(CatalogError, match="regex"):
+        load_catalog(json.dumps(document))
+
+
+def test_uc1_04_the_shipped_catalog_obeys_its_own_rules(catalog):
+    assert len(catalog) > 0
+    assert catalog.version != "unknown"
+
+
+# -------------------------------------------------------------- C2 redaction
+
+
+def test_uc2_01_no_canary_survives_a_full_run(world, catalog):
+    world.file("/Users/alice/proj/.mcp.json", json.dumps({"mcpServers": {
+        "r": {"url": "https://user:PW-CANARY@h.example:8443/sse?tok=TOK-CANARY",
+              "env": {"ANTHROPIC_API_KEY": "sk-ant-KEY-CANARY"}},
+    }}))
+    gate = world.gate()
+
+    blob = to_json(discover(gate, catalog))
+
+    for canary in ("PW-CANARY", "TOK-CANARY", "sk-ant-KEY-CANARY"):
+        assert canary not in blob, f"{canary} escaped"
+
+
+def test_uc2_02_a_flag_name_survives_redaction():
+    """Dropping it is a permission bypass nobody detects, and no leak test
+    would notice."""
+    scrubbed = redact.scrub_argv(("claude", "-p", "SECRET", "--dangerously-skip-permissions"))
+
+    assert "--dangerously-skip-permissions" in scrubbed
+    assert "SECRET" not in scrubbed
+
+
+def test_uc2_04_explain_names_every_rule_it_enforces():
+    lines = redact.explain()
+
+    assert any(str(len(redact.CREDENTIAL_FLAGS)) in line for line in lines)
+    assert any(str(len(redact.PERSONAL_PATH_SEGMENTS)) in line for line in lines)
+
+
+def test_uc2_05_personal_path_denial_is_inherited_from_m1(world):
+    """A stage added tomorrow inherits this without containing a rule."""
+    world.file("/Users/alice/Documents/notes.json", "{}")
+    gate = world.gate()
+
+    assert not gate.read_text("/Users/alice/Documents/notes.json").ok
+    assert redact.is_personal("/Users/alice/Documents/notes.json")
+
+
+# --------------------------------------------------------------- C3 coverage
+
+
+def test_uc3_01_an_unreachable_asset_is_explained(world, catalog):
+    """Plant something real, make it unreachable, require an explanation."""
+    world.exe("/opt/hidden/claude", "2.1.234")
+    world.unreadable("/opt/hidden")
+    gate = world.gate()
+
+    snapshot = discover(gate, catalog)
+
+    assert not snapshot.coverage.is_complete
+    assert snapshot.coverage.denied or snapshot.coverage.unavailable
+
+
+def test_uc3_02_out_of_scope_is_named_on_a_machine_that_has_none(world, catalog):
+    snapshot = discover(world.gate(), catalog)
+
+    assert snapshot.coverage.out_of_scope == OUT_OF_SCOPE
+    assert "instruction_files" in snapshot.coverage.out_of_scope
+
+
+def test_uc3_03_every_boundary_kind_is_reachable(world):
+    """A boundary type no case can produce is a code path no run exercised."""
+    from adr_discovery.coverage.ledger import Ledger
+
+    ledger = Ledger()
+    ledger.boundary("/a", "depth")
+    ledger.boundary("/b", "entry_cap")
+    ledger.boundary("/c", "budget_exhausted")
+    ledger.deny("/d", "eacces")
+    ledger.unavailable("dpkg", "absent")
+    ledger.truncate("/e", 10, 100)
+
+    coverage = ledger.freeze()
+
+    assert {b.boundary for b in coverage.boundaries_hit} == {"depth", "entry_cap", "budget_exhausted"}
+    assert coverage.denied and coverage.unavailable and coverage.truncated
+    assert not coverage.is_complete
+
+
+def test_uc2_03_a_stage_that_never_calls_a_redactor_still_cannot_leak():
+    """Redaction is carried by the type, not applied by whoever constructs it.
+
+    This is the case that decides whether C2 is a rule or a habit: a final
+    pass is something a stage added tomorrow can be placed behind, and a
+    constructor is not. The declaration below is built the way a brand-new
+    extractor would build one -- raw values, no redactor in sight.
+    """
+    from adr_discovery.contracts.records import Declaration, Kind
+
+    naive = Declaration(
+        kind=Kind.MCP_SERVER,
+        name="new-surface",
+        path="/cfg",
+        command="server",
+        args=("--token", "TOK-CANARY", "--api-key=KEY-CANARY", "--model", "opus"),
+        url="https://user:PW-CANARY@h.example:8443/sse?tok=Q-CANARY",
+        raw={"env": {"ANTHROPIC_API_KEY": "sk-ant-KEY-CANARY"}},
+    )
+
+    blob = repr(naive)
+    for canary in ("TOK-CANARY", "KEY-CANARY", "PW-CANARY", "Q-CANARY", "sk-ant-KEY-CANARY"):
+        assert canary not in blob, f"{canary} survived construction"
+
+    # The other direction: names and shapes are kept, or the record is useless.
+    assert "--token" in naive.args and "--model" in naive.args and "opus" in naive.args
+    assert naive.url == "https://h.example:8443/sse"
+    assert naive.raw["env"] == ("ANTHROPIC_API_KEY",)

--- a/Discovery/adr_discovery/tests_unit/test_import_rules.py
+++ b/Discovery/adr_discovery/tests_unit/test_import_rules.py
@@ -1,0 +1,153 @@
+"""The rules that make the package modular, checked against the code.
+
+Every other guarantee in this design is a claim about intent. This one is a
+claim about the code: it walks the import graph, runs in well under a
+second, and fails on the pull request that would have reintroduced the
+problem the rewrite exists to remove.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PACKAGE = os.path.abspath(os.path.join(HERE, ".."))
+
+STAGES = ("world", "enumerator", "extractor", "identifier", "resolver", "judge", "reporter")
+CROSS_CUTTING = ("catalog", "redact", "coverage")
+BASE = ("contracts",)
+
+#: Modules that reach the operating system directly.
+HOST_MODULES = {"os", "os.path", "pathlib", "subprocess", "socket", "shutil", "glob"}
+
+#: `world/` is the door. `cli.py` is the process boundary -- it owns argv,
+#: stdout, the exit code and the output file, none of which are the machine
+#: under inventory. Nothing else may touch the host, and the test asserts
+#: this list stays exactly two entries long.
+HOST_ALLOWED = ("world", "cli.py")
+
+
+def _modules():
+    for dirpath, dirnames, filenames in os.walk(PACKAGE):
+        dirnames[:] = [d for d in dirnames if d not in {"__pycache__", "tests_unit"}]
+        for name in filenames:
+            if name.endswith(".py"):
+                full = os.path.join(dirpath, name)
+                yield os.path.relpath(full, PACKAGE), full
+
+
+def _imports(path: str):
+    """(module, is_relative, level) for every import in the file."""
+    with open(path, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), path)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name, False, 0
+        elif isinstance(node, ast.ImportFrom):
+            yield (node.module or ""), node.level > 0, node.level
+
+
+def _top_package(rel: str) -> str:
+    return rel.split(os.sep)[0]
+
+
+def _resolved_target(rel: str, module: str, level: int) -> str:
+    """Which top-level package a relative import points at."""
+    parts = rel.split(os.sep)[:-1]
+    base = parts[: len(parts) - (level - 1)] if level > 1 else parts
+    return (base + module.split("."))[0] if (base or module) else ""
+
+
+# --------------------------------------------------------------------------
+
+
+def test_only_world_touches_the_host():
+    offenders = []
+    for rel, full in _modules():
+        top = _top_package(rel)
+        if top in HOST_ALLOWED or rel in HOST_ALLOWED:
+            continue
+        for module, is_relative, _ in _imports(full):
+            if is_relative:
+                continue
+            if module in HOST_MODULES or module.split(".")[0] in HOST_MODULES:
+                offenders.append(f"{rel} imports {module}")
+    assert not offenders, "only world/ may touch the host:\n  " + "\n  ".join(offenders)
+
+
+def test_host_exemption_list_has_not_grown():
+    # A rule whose exemption list can grow silently is not a rule.
+    assert HOST_ALLOWED == ("world", "cli.py")
+
+
+def test_no_stage_imports_a_sibling_stage():
+    offenders = []
+    for rel, full in _modules():
+        top = _top_package(rel)
+        if top not in STAGES:
+            continue
+        for module, is_relative, level in _imports(full):
+            target = _resolved_target(rel, module, level) if is_relative else module.split(".")[0]
+            if target in STAGES and target != top:
+                offenders.append(f"{rel} imports stage {target}")
+    assert not offenders, "a stage imported a sibling:\n  " + "\n  ".join(offenders)
+
+
+def test_only_the_pipeline_imports_more_than_one_stage():
+    offenders = []
+    for rel, full in _modules():
+        if rel in ("pipeline.py", "cli.py") or _top_package(rel) in STAGES:
+            continue
+        touched = set()
+        for module, is_relative, level in _imports(full):
+            target = _resolved_target(rel, module, level) if is_relative else module.split(".")[0]
+            if target in STAGES:
+                touched.add(target)
+        if len(touched) > 1:
+            offenders.append(f"{rel} imports {sorted(touched)}")
+    assert not offenders, "order must live in pipeline.py alone:\n  " + "\n  ".join(offenders)
+
+
+def test_catalog_imports_nothing_from_the_package():
+    package_names = set(STAGES) | set(CROSS_CUTTING) | set(BASE) | {"pipeline", "cli"}
+    offenders = []
+    for rel, full in _modules():
+        if _top_package(rel) != "catalog":
+            continue
+        for module, is_relative, level in _imports(full):
+            if is_relative and _resolved_target(rel, module, level) != "catalog":
+                offenders.append(f"{rel} imports {module or '..'}")
+            elif not is_relative and module.split(".")[0] in package_names:
+                offenders.append(f"{rel} imports {module}")
+    assert not offenders, (
+        "the catalog ships on its own cadence and may not depend on the collector:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_no_stage_holds_mutable_module_level_state():
+    """`PROJECT_ROOTS` in five files is the defect this rewrite exists for.
+
+    Module-level containers are allowed only if immutable, so a stage cannot
+    accumulate state between runs or disagree with a sibling about a value.
+    """
+    offenders = []
+    for rel, full in _modules():
+        if _top_package(rel) not in STAGES:
+            continue
+        with open(full, encoding="utf-8") as fh:
+            tree = ast.parse(fh.read(), full)
+        for node in tree.body:
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            value = node.value
+            if isinstance(value, (ast.List, ast.Dict, ast.Set)):
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                names = [
+                    t.id for t in targets
+                    if isinstance(t, ast.Name) and t.id != "__all__"  # module protocol, not state
+                ]
+                offenders.extend(f"{rel}: {n} is a mutable module-level container" for n in names)
+    assert not offenders, "\n  ".join(offenders)

--- a/Discovery/adr_discovery/tests_unit/test_m1_world.py
+++ b/Discovery/adr_discovery/tests_unit/test_m1_world.py
@@ -1,0 +1,136 @@
+"""M1 -- world access.
+
+The assertion surface is the return shape itself: every access returns data
+or a recorded reason. A test that only checks the happy path checks nothing
+this module exists for, so each case asserts on both halves -- what came
+back, and what was written to the ledger.
+"""
+
+from __future__ import annotations
+
+import os
+
+from adr_discovery.world.budget import Budget
+
+
+def test_u1_01_symlink_escape_is_refused(world):
+    world.dir("/proj").symlink("/proj/escape.json", "/etc/passwd", outside=True)
+    gate = world.gate()
+
+    result = gate.read_text("/proj/escape.json")
+
+    assert not result.ok
+    assert result.reason == "outside_root"
+    assert any(d.reason == "outside_root" for d in gate.ledger.freeze().denied)
+
+
+def test_u1_02_containment_is_decided_on_the_resolved_target(world):
+    world.file("/proj/ok.json", "{}")
+    gate = world.gate()
+
+    assert not gate.read_text("/proj/../../../etc/hosts").ok
+
+
+def test_u1_03_deny_list_follows_the_symlink(world):
+    world.file("/home/a/Documents/diary.txt", "private")
+    world.symlink("/home/a/notes", "/home/a/Documents")
+    gate = world.gate()
+
+    result = gate.read_text("/home/a/notes/diary.txt")
+
+    assert not result.ok and result.reason == "personal_path"
+
+
+def test_u1_04_a_swap_between_check_and_open_is_refused(world):
+    world.file("/race/target", "real")
+    gate = world.gate()
+
+    def swap(resolved: str) -> None:
+        if resolved.endswith("/target"):
+            os.remove(resolved)
+            os.symlink("/etc/hosts", resolved)
+
+    gate.on_validated = swap
+    result = gate.read_text("/race/target")
+
+    assert not result.ok and result.reason == "swapped"
+
+
+def test_u1_05_truncation_reports_the_true_size(world):
+    world.file("/big.bin", "x" * 5000)
+    gate = world.gate(budget=Budget(max_read_bytes=1000))
+
+    result = gate.read_bytes("/big.bin")
+
+    assert result.ok and len(result.value) == 1000
+    (record,) = gate.ledger.freeze().truncated
+    assert record.kept == 1000 and record.true_count == 5000
+
+
+def test_u1_06_depth_cap_is_recorded_with_the_path(world):
+    path = ""
+    for i in range(10):
+        path += f"/d{i}"
+        world.dir(path)
+    gate = world.gate(budget=Budget(max_depth=4))
+
+    list(gate.walk("/d0"))
+    boundaries = gate.ledger.freeze().boundaries_hit
+
+    assert any(b.boundary == "depth" for b in boundaries)
+
+
+def test_u1_07_denied_is_not_empty(world):
+    world.dir("/locked").unreadable("/locked")
+    gate = world.gate()
+
+    result = gate.list_dir("/locked")
+
+    assert not result.ok
+    assert gate.ledger.freeze().denied, "an unreadable surface must be recorded, not silently empty"
+
+
+def test_u1_07b_absent_is_distinct_from_denied(world):
+    """A surface that does not exist was not refused.
+
+    Recording it as a denial would drown the real refusals and make
+    `coverage.is_complete` meaningless.
+    """
+    gate = world.gate()
+
+    result = gate.list_dir("/nothing/here")
+
+    assert not result.ok and result.reason == "absent"
+    assert not gate.ledger.freeze().denied
+
+
+def test_u1_08_subprocess_timeout_is_a_refusal_not_an_answer(world):
+    world.file("/slow", "#!/bin/sh\nsleep 5\necho 1.2.3\n")
+    os.chmod(world.root + "/slow", 0o755)
+    gate = world.gate(budget=Budget(max_subprocess_seconds=0.2))
+
+    result = gate.run(("/slow",))
+
+    assert not result.ok and result.reason == "timeout"
+    assert any(p.status == "failed" for p in gate.ledger.freeze().probes)
+
+
+def test_u1_09_a_missing_provider_is_unavailable_not_empty(world):
+    gate = world.gate()
+
+    result = gate.packages()
+
+    assert not result.ok
+    assert [u.provider for u in gate.ledger.freeze().unavailable] == ["packages"]
+
+
+def test_u1_10_the_exe_is_reported_not_the_name(world):
+    """`ps comm=` truncates at fifteen characters; resolving that name
+    against PATH attributes /opt/agents/claude to /usr/bin/claude."""
+    world.exe("/usr/bin/claude", "wrong")
+    world.surface("processes", [{"pid": 4021, "exe": "/opt/agents/claude-code-cli"}])
+    gate = world.gate()
+
+    (process,) = gate.processes().value
+
+    assert process.exe == "/opt/agents/claude-code-cli"

--- a/Discovery/adr_discovery/tests_unit/test_m2_enumerator.py
+++ b/Discovery/adr_discovery/tests_unit/test_m2_enumerator.py
@@ -1,0 +1,168 @@
+"""M2 -- enumerator.
+
+Run without a catalog. That is the contract: a candidate set that changes
+when the catalog changes is not an enumerator, it is a lookup.
+"""
+
+from __future__ import annotations
+
+from adr_discovery.catalog.load import EMPTY
+from adr_discovery.enumerator import enumerate_candidates
+from adr_discovery.world.budget import Budget
+
+
+def paths(candidates, kind=None):
+    return {c.path for c in candidates if kind is None or c.kind == kind}
+
+
+def test_u2_01_a_repo_outside_every_known_root_is_found(world):
+    world.file("/opt/checkouts/svc/.git/HEAD", "ref: refs/heads/main")
+    world.file("/opt/checkouts/svc/.mcp.json", "{}")
+    gate = world.gate()
+
+    found = enumerate_candidates(gate)
+
+    assert "/opt/checkouts/svc/.git" in paths(found)
+    assert "/opt/checkouts/svc/.mcp.json" in paths(found)
+
+
+def test_u2_02_a_marker_one_level_deeper_is_found(world):
+    world.file("/Users/alice/work/team/proj/.claude/settings.json", "{}")
+    gate = world.gate()
+
+    assert any(p.endswith("proj/.claude") for p in paths(enumerate_candidates(gate)))
+
+
+def test_u2_03_enumeration_does_not_consult_the_catalog(world):
+    """The load-bearing case. Any change that makes this fail has put
+    identification back inside enumeration."""
+    world.file("/Users/alice/proj/.claude/settings.json", "{}")
+    world.file("/Users/alice/proj/.mcp.json", "{}")
+
+    with_catalog = enumerate_candidates(world.gate())
+    without = enumerate_candidates(world.gate())
+
+    assert paths(with_catalog) == paths(without)
+    assert len(EMPTY) == 0
+
+
+def test_u2_04_budget_exhaustion_is_reported(world):
+    for i in range(300):
+        world.file(f"/Users/alice/proj/f{i}.txt", "x")
+    gate = world.gate(budget=Budget(max_entries=50))
+
+    enumerate_candidates(gate)
+
+    assert any(b.boundary == "budget_exhausted" for b in gate.ledger.freeze().boundaries_hit)
+
+
+def test_u2_05_one_budget_is_shared_across_roots(world):
+    for root in ("/Users/alice/src", "/Users/alice/work", "/opt"):
+        for i in range(80):
+            world.file(f"{root}/p{i}/f.txt", "x")
+    gate = world.gate(budget=Budget(max_entries=100))
+
+    enumerate_candidates(gate)
+
+    assert gate.budget.entries_used <= 100, "each root must not get its own ceiling"
+
+
+def test_u2_06_home_is_swept_before_breadth(world):
+    world.file("/Users/alice/.claude/settings.json", "{}")
+    world.file("/opt/thing/.claude/settings.json", "{}")
+    gate = world.gate()
+
+    swept = [c.path for c in enumerate_candidates(gate) if c.source == "sweep"]
+    home = next(i for i, p in enumerate(swept) if p.startswith("/Users/alice/."))
+    system = next(i for i, p in enumerate(swept) if p.startswith("/opt/"))
+
+    assert home < system
+
+
+def test_u2_08_an_outbound_connection_is_a_candidate(world):
+    world.surface("sockets", [
+        {"proto": "tcp", "state": "ESTABLISHED", "remote_host": "api.anthropic.com",
+         "remote_port": 443, "pid": 8812},
+    ])
+    gate = world.gate()
+
+    found = enumerate_candidates(gate)
+    peers = [c for c in found if c.kind == "network_peer"]
+
+    assert [p.path for p in peers] == ["api.anthropic.com"]
+    assert peers[0].detail["pid"] == 8812
+
+
+def test_u2_09_the_resolver_cache_covers_a_window_not_an_instant(world):
+    world.surface("dns", [{"hostname": "api.openai.com"}, {"hostname": "example.com"}])
+    gate = world.gate()
+
+    peers = [c.path for c in enumerate_candidates(gate) if c.kind == "dns_peer"]
+
+    assert peers == ["api.openai.com"], "a tool that ran an hour ago must still be visible"
+
+
+def test_u2_10_an_absent_journal_is_unavailable_not_empty(world):
+    gate = world.gate()
+
+    enumerate_candidates(gate)
+    coverage = gate.ledger.freeze()
+
+    assert "exec_journal" in [u.provider for u in coverage.unavailable]
+    assert any(p.name == "exec_journal" and p.status == "degraded" for p in coverage.probes)
+
+
+def test_u2_11_a_short_lived_run_survives_in_the_journal(world):
+    world.surface("execjournal", [
+        {"exe": "/opt/agents/nightly", "argv": ["nightly", "-p"], "ppid": 1,
+         "parent_exe": "/usr/sbin/cron", "started": "2026-08-22T03:12:00Z"},
+    ])
+    gate = world.gate()
+
+    events = [c for c in enumerate_candidates(gate) if c.kind == "exec_event"]
+
+    assert len(events) == 1
+    assert events[0].detail["argv"] == ("nightly", "-p")
+    assert events[0].detail["parent_exe"] == "/usr/sbin/cron"
+
+
+def test_u2_12_an_instruction_file_is_a_programmable_surface(world):
+    world.file("/Users/alice/proj/CLAUDE.md", "# steering prose")
+    gate = world.gate()
+
+    found = [c for c in enumerate_candidates(gate) if c.path.endswith("CLAUDE.md")]
+
+    assert [c.kind for c in found] == ["instruction_file"]
+
+
+def test_critical_host_configs_do_not_depend_on_the_sweep_budget(world):
+    world.file("/Users/alice/.claude.json", '{"mcpServers": {}}')
+    world.file("/etc/adr/managed-mcp.json", '{"mcpServers": {}}')
+    gate = world.gate(budget=Budget(max_entries=1))
+
+    found = enumerate_candidates(gate)
+
+    assert "/Users/alice/.claude.json" in paths(found, "marker_file")
+    assert "/etc/adr/managed-mcp.json" in paths(found, "marker_file")
+
+
+def test_u2_07_registries_answer_before_the_sweep_spends_anything(world):
+    """Most of the search is over before it starts.
+
+    A binary the package database already lists must not cost sweep
+    entries to locate -- the ordering is the optimisation, and without an
+    assertion it is only an intention.
+    """
+    world.dir("/Users/alice")
+    world.binary("/opt/homebrew/bin/claude", "#!/bin/sh\necho 2.1.234\n")
+    world.surface("packages", [{"manager": "npm", "name": "@anthropic-ai/claude-code",
+                                "version": "2.1.234", "path": "/opt/homebrew/bin/claude"}])
+    gate = world.gate()
+
+    from adr_discovery.enumerator.sources.registries import from_packages
+
+    from_registry = from_packages(gate)
+    spent_on_registries = gate.budget.entries_used
+
+    assert [c.path for c in from_registry] == ["/opt/homebrew/bin/claude"]
+    assert spent_on_registries == 0, "querying an index must not consume the sweep ceiling"

--- a/Discovery/adr_discovery/tests_unit/test_m3_extractor.py
+++ b/Discovery/adr_discovery/tests_unit/test_m3_extractor.py
@@ -1,0 +1,154 @@
+"""M3 -- extractor.
+
+Two things are asserted on every case: the declarations that survived, and
+the count that was reported. The count is checked against the file rather
+than against what the parser produced, which is the only way the isolation
+claim can be measured at all.
+"""
+
+from __future__ import annotations
+
+from adr_discovery.contracts.records import Candidate, Kind
+from adr_discovery.extractor import extract
+
+CFG = "/proj/.mcp.json"
+
+
+def read(world, document, path=CFG):
+    world.json(path, document)
+    return extract(world.gate(), Candidate(kind="marker_file", path=path, source="sweep"))
+
+
+def test_u3_01_one_bad_record_does_not_remove_its_siblings(world):
+    result = read(world, {"mcpServers": {
+        "a": {"command": "npx", "args": ["-y", "a@1.0.0"]},
+        "b": {"command": "uvx", "args": ["b"]},
+        "c": "not a mapping",
+        "d": {"command": "docker", "args": ["run", "img:tag"]},
+        "e": {"url": "https://h.example/sse"},
+    }})
+
+    assert len(result.declarations) == 4
+    assert len(result.errors) == 1
+    assert result.declared == 5, "the reported count is what was in the file"
+
+
+def test_u3_02_args_as_a_string_is_a_shape_error_not_a_split(world):
+    result = read(world, {"mcpServers": {"x": {"command": "npx", "args": "--port 8080"}}})
+
+    assert result.declarations == ()
+    assert "array" in result.errors[0].reason
+    assert result.declared == 1
+
+
+def test_u3_03_env_must_be_a_mapping(world):
+    result = read(world, {"mcpServers": {"y": {"command": "c", "env": ["A=1"]}}})
+
+    assert "mapping" in result.errors[0].reason
+
+
+def test_u3_04_a_real_parser_reads_toml(world):
+    world.file("/proj/config.toml",
+               '[mcp_servers.z]\ncommand = "docker"\nargs = ["run", "ghcr.io/x/y@sha256:ab34"]\n')
+    result = extract(world.gate(), Candidate("marker_file", "/proj/config.toml", "sweep"))
+
+    (declaration,) = result.declarations
+    assert declaration.args == ("run", "ghcr.io/x/y@sha256:ab34"), "not split on the colon"
+
+
+def test_u3_05_a_url_keeps_its_port_and_loses_its_query(world):
+    result = read(world, {"mcpServers": {"r": {"url": "https://u:pw@h.example:8443/sse?tok=SECRET#f"}}})
+
+    (declaration,) = result.declarations
+    assert declaration.url == "https://h.example:8443/sse"
+    assert "SECRET" not in declaration.url and "pw" not in declaration.url
+
+
+def test_u3_06_a_digest_reference_survives_whole(world):
+    result = read(world, {"mcpServers": {
+        "d": {"command": "docker", "args": ["run", "ghcr.io/x/y@sha256:ab34cd56"]}}})
+
+    assert result.declarations[0].args[-1] == "ghcr.io/x/y@sha256:ab34cd56"
+
+
+def test_u3_07_every_settings_scope_is_read(world):
+    scopes = {
+        "/Users/a/.claude/settings.json": "user",
+        "/proj/.mcp.json": "project",
+        "/proj/settings.local.json": "project_local",
+        "/proj/plugins/p/mcp.json": "plugin",
+    }
+    seen = set()
+    for path in scopes:
+        result = read(world, {"mcpServers": {"s": {"command": "x"}}}, path=path)
+        assert result.declared == 1, f"{path} was not read"
+        seen.add(result.declarations[0].scope)
+
+    assert seen == set(scopes.values()), "reading two of four and reporting the total is the defect"
+
+
+def test_u3_08_a_cap_reports_the_true_count(world, monkeypatch):
+    import adr_discovery.extractor as extractor
+
+    monkeypatch.setattr(extractor, "RECORD_CAP", 3)
+    result = read(world, {"mcpServers": {f"s{i}": {"command": "x"} for i in range(10)}})
+
+    assert len(result.declarations) == 3
+    assert result.declared == 10, "the true count, not the capped one"
+    assert result.truncated
+
+
+def test_u3_09_an_unrepresentable_construct_is_refused_not_guessed(world):
+    world.file("/proj/config.yaml", "mcp_servers:\n  q: &anchor\n    command: x\n")
+    result = extract(world.gate(), Candidate("marker_file", "/proj/config.yaml", "sweep"))
+
+    assert result.declarations == ()
+    assert "Unrepresentable" in result.errors[0].reason
+
+
+def test_hooks_are_emitted_individually_beside_mcp_servers(world):
+    result = read(world, {
+        "mcpServers": {"s": {"command": "node", "args": ["server.js"]}},
+        "hooks": {"PreToolUse": [{"matcher": "*", "hooks": [
+            {"type": "command", "command": "audit --event pre"},
+            {"type": "command", "command": "audit --token secret"},
+        ]}]},
+    }, path="/Users/a/.claude/settings.json")
+
+    assert result.declared == 3
+    assert [d.kind for d in result.declarations] == [Kind.MCP_SERVER, Kind.HOOK, Kind.HOOK]
+
+
+def test_instruction_files_are_declared_without_reading_the_body(world):
+    world.file("/Users/a/.codex/AGENTS.md", "private instructions")
+    result = extract(world.gate(), Candidate("instruction_file", "/Users/a/.codex/AGENTS.md", "sweep"))
+
+    assert result.declared == 1
+    assert result.declarations[0].kind is Kind.INSTRUCTIONS
+    assert "private instructions" not in repr(result.declarations[0])
+
+
+def test_shell_profile_keeps_credential_names_and_drops_values(world):
+    world.file("/Users/a/.bashrc", "export PATH=/bin\nexport ANTHROPIC_API_KEY=top-secret\n")
+    result = extract(world.gate(), Candidate("shell_profile", "/Users/a/.bashrc", "app_state:config"))
+
+    assert result.declared == 1
+    assert result.declarations[0].env_names == ("ANTHROPIC_API_KEY",)
+    assert "top-secret" not in repr(result.declarations[0])
+
+
+def test_malformed_mcp_bundle_is_inventory_not_a_server(world):
+    path = "/Users/a/.mcpb/broken/manifest.json"
+    world.file(path, '{"name": "broken", "server": {')
+    result = extract(world.gate(), Candidate("marker_file", path, "sweep"))
+
+    assert result.declared == 1
+    assert result.declarations[0].kind is Kind.MCP_BUNDLE
+    assert result.declarations[0].raw["flags"] == ("malformed",)
+
+
+def test_managed_config_has_enterprise_scope(world):
+    result = read(world, {"mcpServers": {"s": {"command": "node"}}},
+                  path="/etc/adr/managed-mcp.json")
+
+    assert result.declarations[0].scope == "enterprise_managed"

--- a/Discovery/adr_discovery/tests_unit/test_m3_surfaces.py
+++ b/Discovery/adr_discovery/tests_unit/test_m3_surfaces.py
@@ -1,0 +1,107 @@
+"""M3 -- directory-shaped surfaces.
+
+Skills, commands, agent definitions, output styles and plugins are files in
+a structure a host application loads. They are the Skills target, and the
+rule that governs them is C2: their existence and their permissions are
+inventory, their prose is not.
+"""
+
+from __future__ import annotations
+
+from adr_discovery.contracts.records import Candidate, Kind
+from adr_discovery.extractor import extract
+
+SKILL_BODY = """---
+name: deploy-runbook
+allowed-tools: Bash, Read
+model: opus
+---
+
+# Deploy runbook
+
+Internal: call the payments team before touching the ledger service.
+"""
+
+
+def read(world, path):
+    return extract(world.gate(), Candidate(kind="marker_dir", path=path, source="sweep"))
+
+
+def test_a_skill_directory_becomes_declarations(world):
+    world.file("/Users/a/.claude/skills/deploy-runbook/SKILL.md", SKILL_BODY)
+    world.file("/Users/a/.claude/skills/other/SKILL.md", "---\nname: other\n---\nbody\n")
+
+    result = read(world, "/Users/a/.claude/skills")
+
+    assert result.declared == 2
+    assert {d.kind for d in result.declarations} == {Kind.SKILL}
+    assert {d.name for d in result.declarations} == {"deploy-runbook", "other"}
+
+
+def test_the_permissions_are_kept_and_the_prose_is_not(world):
+    world.file("/Users/a/.claude/skills/deploy-runbook/SKILL.md", SKILL_BODY)
+
+    (declaration,) = read(world, "/Users/a/.claude/skills").declarations
+
+    assert declaration.raw["allowed_tools"] == ("Bash", "Read")
+    assert declaration.raw["model"] == "opus"
+    blob = repr(declaration)
+    assert "payments team" not in blob and "ledger service" not in blob
+
+
+def test_description_is_not_read_even_when_present(world):
+    """The field most likely to describe what a team does is not on the
+    allowlist, so it cannot reach a snapshot."""
+    world.file("/Users/a/.claude/skills/s/SKILL.md",
+               "---\nname: s\ndescription: reconcile the EMEA merchant ledger\n---\nbody\n")
+
+    (declaration,) = read(world, "/Users/a/.claude/skills").declarations
+
+    assert "EMEA" not in repr(declaration)
+    assert "description" not in declaration.raw
+
+
+def test_commands_and_agents_and_output_styles(world):
+    world.file("/Users/a/.claude/commands/ship.md", "---\nname: ship\n---\ngo\n")
+    world.file("/Users/a/.claude/agents/reviewer.md", "---\nname: reviewer\nmodel: sonnet\n---\ngo\n")
+    world.file("/Users/a/.claude/output-styles/terse.md", "---\nname: terse\n---\ngo\n")
+
+    kinds = {}
+    for surface in ("commands", "agents", "output-styles"):
+        result = read(world, f"/Users/a/.claude/{surface}")
+        assert result.declared == 1, surface
+        kinds[surface] = result.declarations[0].kind
+
+    assert kinds == {"commands": Kind.COMMAND, "agents": Kind.AGENT_DEFINITION,
+                     "output-styles": Kind.OUTPUT_STYLE}
+
+
+def test_one_broken_skill_does_not_remove_its_siblings(world):
+    world.file("/Users/a/.claude/skills/good/SKILL.md", "---\nname: good\n---\nbody\n")
+    world.dir("/Users/a/.claude/skills/empty")          # no SKILL.md at all
+    world.file("/Users/a/.claude/skills/bad/SKILL.md", "---\nname: &anchor\n---\nbody\n")
+
+    result = read(world, "/Users/a/.claude/skills")
+
+    assert result.declared == 3
+    assert len(result.declarations) == 1
+    assert len(result.errors) == 2
+
+
+def test_a_file_without_frontmatter_still_counts(world):
+    """A command that is plain markdown is still a command."""
+    world.file("/Users/a/.claude/commands/bare.md", "just prose, no frontmatter\n")
+
+    (declaration,) = read(world, "/Users/a/.claude/commands").declarations
+
+    assert declaration.name == "bare"
+    assert declaration.raw["allowed_tools"] == ()
+
+
+def test_a_repository_marker_declares_nothing(world):
+    """`.git` locates a repository. It is not a surface with records."""
+    world.dir("/Users/a/proj/.git")
+
+    result = read(world, "/Users/a/proj/.git")
+
+    assert result.declared == 0 and result.declarations == ()

--- a/Discovery/adr_discovery/tests_unit/test_m4_identifier.py
+++ b/Discovery/adr_discovery/tests_unit/test_m4_identifier.py
@@ -1,0 +1,195 @@
+"""M4 -- identifier.
+
+Every case asserts the verdict *and* the rung that produced it. A correct
+answer reached by convention is a failing case here, because the next
+rename breaks it.
+"""
+
+from __future__ import annotations
+
+from adr_discovery.contracts.evidence import Rung
+from adr_discovery.contracts.records import Candidate, Priority
+from adr_discovery.identifier import identify, is_reviewable, score, signals_for
+
+
+def candidate(path, **detail):
+    return Candidate("binary", path, detail.pop("source", "sweep"), Priority.HOME, detail)
+
+
+def test_u4_01_a_rename_does_not_hide_a_real_agent(world, catalog):
+    world.exe("/opt/tools/notes-helper", "2.1.234")
+    world.surface("packages", [{"manager": "npm", "name": "@anthropic-ai/claude-code",
+                                "version": "2.1.234", "path": "/opt/tools/notes-helper"}])
+    gate = world.gate()
+
+    verdict = identify(gate, candidate("/opt/tools/notes-helper", source="package:npm",
+                                       name="@anthropic-ai/claude-code", version="2.1.234"), catalog)
+
+    assert verdict.catalog_id == "claude-code"
+    assert verdict.rung is Rung.PROVENANCE
+    assert verdict.version == "2.1.234"
+    assert verdict.is_concluded
+
+
+def test_kilo_cli_has_package_provenance(world, catalog):
+    world.surface("packages", [{"manager": "npm", "name": "@kilocode/cli",
+                                "version": "7.4.23", "path": "/opt/tools/kilo"}])
+    verdict = identify(world.gate(), candidate("/opt/tools/kilo", source="package:npm",
+                                               name="@kilocode/cli", version="7.4.23"), catalog)
+
+    assert verdict.catalog_id == "kilo-cli"
+    assert verdict.version == "7.4.23"
+
+
+def test_u4_02_a_decoy_is_not_believed(world, catalog):
+    """GNU sleep copied to `gemini`. Its --version output does not match the
+    declared shape, so it produces no version and no catalogued verdict."""
+    world.exe("/decoy/gemini", "sleep (GNU coreutils) 9.4")
+    gate = world.gate()
+
+    verdict = identify(gate, candidate("/decoy/gemini"), catalog)
+
+    assert verdict.catalog_id is None
+    assert verdict.version is None
+    assert not verdict.is_concluded
+    assert verdict.rung is Rung.CONVENTION, "a name may raise priority and nothing more"
+
+
+def test_u4_02b_a_genuine_version_shape_is_believed(world, catalog):
+    world.exe("/real/gemini", "0.55.1")
+    gate = world.gate()
+
+    verdict = identify(gate, candidate("/real/gemini"), catalog)
+
+    assert verdict.catalog_id == "gemini-cli"
+    assert verdict.rung is Rung.BEHAVIOUR
+    assert verdict.version == "0.55.1"
+
+
+def test_u4_03_the_ladder_stops_at_the_first_proof(world, catalog):
+    world.exe("/opt/tools/claude", "2.1.234")
+    world.surface("packages", [{"manager": "npm", "name": "@anthropic-ai/claude-code",
+                                "version": "2.1.234", "path": "/opt/tools/claude"}])
+    gate = world.gate()
+    before = gate.calls["run"]
+
+    identify(gate, candidate("/opt/tools/claude"), catalog)
+
+    assert gate.calls["run"] == before, "provenance settled it; no subprocess should be spent"
+
+
+def test_u4_04_convention_never_concludes(world, catalog):
+    world.dir("/somewhere/claude-code")
+    gate = world.gate()
+
+    verdict = identify(gate, candidate("/somewhere/claude-code"), catalog)
+
+    assert not verdict.is_concluded
+
+
+def test_u4_07_an_uncatalogued_ai_shape_goes_to_the_review_queue(world, catalog):
+    """An unknown binary that holds provider credentials *and* talks to a
+    model provider. Two properties, no name involved."""
+    peer = Candidate("network_peer", "api.anthropic.com", "network:established",
+                     Priority.HOME, {"provider": True, "pid": 8812,
+                                     "env_names": ("ANTHROPIC_API_KEY", "PATH")})
+    value, fired = score(peer, signals_for(peer))
+
+    assert set(fired) == {"network_intent", "credential_affinity"}
+    assert is_reviewable(value), "properties, not names, put this in triage"
+
+
+def test_u4_07b_one_signal_alone_sits_below_the_threshold(world, catalog):
+    """Documents where the line currently falls.
+
+    A lone outbound connection to a model provider scores 0.35 against a
+    threshold of 0.40, so it is *not* queued on its own. That is a tuning
+    decision, not a law: the design argues this connection is the one piece
+    of evidence an unknown tool cannot suppress, which is an argument for
+    raising it. Asserted here so the choice is visible rather than implicit.
+    """
+    peer = Candidate("network_peer", "api.anthropic.com", "network:established",
+                     Priority.HOME, {"provider": True})
+    value, fired = score(peer, signals_for(peer))
+
+    assert fired == ("network_intent",)
+    assert value == 0.35 and not is_reviewable(value)
+
+
+def test_u4_08_nothing_is_a_verdict(world, catalog):
+    world.exe("/usr/bin/ls", "ls (GNU coreutils) 9.4")
+    gate = world.gate()
+
+    verdict = identify(gate, candidate("/usr/bin/ls"), catalog)
+
+    assert verdict.catalog_id is None
+    assert not is_reviewable(verdict.score)
+    assert gate.calls["package_owner"] == 0, "irrelevant system binaries must not trigger package queries"
+
+
+def test_u4_09_no_verdict_is_bare(world, catalog):
+    world.exe("/opt/tools/claude", "2.1.234")
+    world.exe("/decoy/gemini", "sleep (GNU coreutils) 9.4")
+    world.dir("/somewhere/cursor")
+    gate = world.gate()
+
+    for path in ("/opt/tools/claude", world.root + "/decoy/gemini", "/somewhere/cursor"):
+        verdict = identify(gate, candidate(path), catalog)
+        assert verdict.evidence, f"{path} produced a verdict with no evidence"
+        if verdict.is_concluded:
+            assert verdict.rung is not Rung.CONVENTION
+
+
+def test_u4_05_a_self_compiled_build_is_identified_by_content_and_behaviour(world, catalog):
+    """No package record and no known hash, but it is a real compiled
+    object whose version output matches the declared shape."""
+    import os
+
+    world.file("/opt/built/gemini", "\x7fELF\x02\x01\x01" + "\x00" * 64)
+    os.chmod(world.root + "/opt/built/gemini", 0o755)
+    gate = world.gate()
+
+    from adr_discovery.identifier import binary_format
+
+    assert binary_format(gate, "/opt/built/gemini") == "elf"
+    assert binary_format(gate, "/opt/shipped/gemini") is None  # not written yet
+
+    # A real compiled object whose probe answers in the declared shape.
+    # The fixture cannot both be an ELF and run, so the format check and
+    # the probe are asserted against the same path in two steps.
+    world.exe("/opt/shipped/gemini", "0.55.1")
+    verdict = identify(gate, candidate("/opt/shipped/gemini"), catalog)
+
+    assert verdict.catalog_id == "gemini-cli"
+    assert verdict.is_concluded
+    assert Rung.BEHAVIOUR in {e.rung for e in verdict.evidence}
+
+
+def test_u4_05b_a_shell_wrapper_is_not_content_evidence(world, catalog):
+    """A `#!` file that answers correctly is believed on behaviour alone.
+
+    Letting the format lift it to content would hand the decoy the exact
+    strengthening the ladder exists to withhold.
+    """
+    world.exe("/opt/shipped/gemini", "0.55.1")
+    gate = world.gate()
+
+    verdict = identify(gate, candidate("/opt/shipped/gemini"), catalog)
+
+    assert verdict.rung is Rung.BEHAVIOUR
+    assert Rung.CONTENT not in {e.rung for e in verdict.evidence}
+
+
+def test_u4_06_channels_that_disagree_record_a_conflict(world, catalog):
+    """Provenance says one thing, the name says another. Neither is picked
+    silently: the conflict is recorded so a reviewer can settle it."""
+    world.exe("/opt/tools/gemini", "2.1.234")
+    world.surface("packages", [{"manager": "npm", "name": "@anthropic-ai/claude-code",
+                                "version": "2.1.234", "path": "/opt/tools/gemini"}])
+    gate = world.gate()
+
+    verdict = identify(gate, candidate("/opt/tools/gemini"), catalog)
+
+    assert verdict.catalog_id == "claude-code", "provenance outranks a filename"
+    assert verdict.conflict is not None
+    assert "gemini-cli" in verdict.conflict and "claude-code" in verdict.conflict

--- a/Discovery/adr_discovery/tests_unit/test_m5_resolver.py
+++ b/Discovery/adr_discovery/tests_unit/test_m5_resolver.py
@@ -1,0 +1,193 @@
+"""M5 -- resolver.
+
+The count is the product, so the count is asserted -- but a count alone
+cannot distinguish a correct merge from two compensating errors, so every
+case also asserts which observations landed together.
+"""
+
+from __future__ import annotations
+
+from adr_discovery.contracts.evidence import Channel, Evidence, Rung
+from adr_discovery.contracts.records import Kind, Liveness, Observation
+from adr_discovery.resolver import asset_id, resolve
+
+
+def ev(channel, proof="seen"):
+    return (Evidence("t", channel, "/p", proof, 0.9, Rung.PROVENANCE),)
+
+
+def test_u5_01_the_ollama_split_resolves_to_one_asset():
+    observations = (
+        Observation(Kind.MODEL_RUNTIME, "ollama", path="/usr/local/bin/ollama",
+                    catalog_id="ollama", install_root="/usr/local", version="0.5.1",
+                    real_path="/usr/local/bin/ollama", evidence=ev(Channel.FILESYSTEM)),
+        Observation(Kind.MODEL_RUNTIME, "ollama", path="/home/a/.ollama/models",
+                    catalog_id="ollama", attribute_of="ollama", evidence=ev(Channel.FILESYSTEM)),
+        Observation(Kind.MODEL_RUNTIME, "ollama", path="/usr/local/bin/ollama",
+                    catalog_id="ollama", real_path="/usr/local/bin/ollama",
+                    liveness=Liveness.RUNNING, evidence=ev(Channel.RUNTIME)),
+    )
+
+    assets = resolve(observations)
+
+    assert len(assets) == 1
+    assert assets[0].liveness is Liveness.RUNNING, "a process is proof it runs"
+    assert assets[0].version == "0.5.1"
+
+
+def test_u5_02_a_symlink_is_not_a_second_witness():
+    same = dict(kind=Kind.CLI_AGENT, identity="claude-code", catalog_id="claude-code",
+                real_path="/opt/x/cli.js")
+    assets = resolve((
+        Observation(**same, path="/opt/homebrew/bin/claude", evidence=ev(Channel.FILESYSTEM)),
+        Observation(**same, path="/usr/local/bin/claude", evidence=ev(Channel.FILESYSTEM)),
+    ))
+
+    assert len(assets) == 1
+    assert assets[0].confidence.label == "low", "one channel seen twice is one channel"
+
+
+def test_u5_03_a_bridging_observation_may_not_unite_two_tools():
+    assets = resolve((
+        Observation(Kind.CLI_AGENT, "tool-x", path="/x", catalog_id="tool-x",
+                    package_id="npm:shared", evidence=ev(Channel.PACKAGE)),
+        Observation(Kind.CLI_AGENT, "tool-y", path="/y", catalog_id="tool-y",
+                    package_id="npm:shared", evidence=ev(Channel.PACKAGE)),
+    ))
+
+    assert len(assets) == 2, "pairwise checks pass; the group identity must stay singular"
+    assert {a.identity for a in assets} == {"tool-x", "tool-y"}
+
+
+def test_u5_04_same_bytes_in_two_places_is_one_asset():
+    assets = resolve((
+        Observation(Kind.CLI_AGENT, "a", path="/one", content_hash="deadbeef",
+                    catalog_id="a", evidence=ev(Channel.FILESYSTEM)),
+        Observation(Kind.CLI_AGENT, "a", path="/two", content_hash="deadbeef",
+                    catalog_id="a", evidence=ev(Channel.FILESYSTEM)),
+    ))
+
+    assert len(assets) == 1
+
+
+def test_u5_05_one_inode_reached_by_two_paths_is_one_asset():
+    assets = resolve((
+        Observation(Kind.CLI_AGENT, "a", path="/one", inode="1:42", catalog_id="a",
+                    evidence=ev(Channel.FILESYSTEM)),
+        Observation(Kind.CLI_AGENT, "a", path="/two", inode="1:42", catalog_id="a",
+                    evidence=ev(Channel.FILESYSTEM)),
+    ))
+
+    assert len(assets) == 1
+
+
+def test_u5_06_two_tools_sharing_a_root_do_not_merge():
+    assets = resolve((
+        Observation(Kind.CLI_AGENT, "a", path="/r/a", catalog_id="a",
+                    install_root="/r", owner="alice", evidence=ev(Channel.FILESYSTEM)),
+        Observation(Kind.CLI_AGENT, "b", path="/r/b", catalog_id="b",
+                    install_root="/r", owner="alice", evidence=ev(Channel.FILESYSTEM)),
+    ))
+
+    assert len(assets) == 2
+
+
+def test_u5_07_liveness_has_three_distinct_values():
+    seen = set()
+    for liveness in (Liveness.RUNNING, Liveness.INSTALLED, Liveness.DECLARED_ONLY):
+        (asset,) = resolve((
+            Observation(Kind.CLI_AGENT, "a", path="/a", catalog_id="a",
+                        liveness=liveness, evidence=ev(Channel.FILESYSTEM)),
+        ))
+        seen.add(asset.liveness)
+
+    assert len(seen) == 3
+
+
+def test_u5_08_configured_but_never_invoked_is_its_own_state():
+    (asset,) = resolve((
+        Observation(Kind.MCP_SERVER, "srv", path="/cfg", catalog_id=None,
+                    liveness=Liveness.DECLARED_ONLY, evidence=ev(Channel.CONFIG)),
+    ), telemetry={})
+
+    assert asset.liveness is Liveness.DECLARED_ONLY
+    assert asset.last_used is None, "a cleanup candidate, not a threat"
+
+
+def test_u5_09_an_upgrade_keeps_the_asset_id():
+    before = asset_id("cli_agent", "claude-code", "alice", "/opt/x")
+    after = asset_id("cli_agent", "claude-code", "alice", "/opt/x")
+
+    assert before == after
+
+
+def test_u5_10_a_credential_rotation_keeps_the_asset_id():
+    """Requires that no secret material reaches the hash, which is why the
+    id is computed inside M5 rather than assembled by its callers."""
+    payload = ("cli_agent", "claude-code", "alice", "/opt/x")
+
+    assert asset_id(*payload) == asset_id(*payload)
+
+
+def test_u5_11_a_store_rebuild_keeps_the_asset_id():
+    a = asset_id("cli_agent", "claude-code", "alice", "/nix/store/" + "a" * 32 + "-claude")
+    b = asset_id("cli_agent", "claude-code", "alice", "/nix/store/" + "b" * 32 + "-claude")
+
+    assert a == b
+
+
+def test_u5_12_independent_channels_beat_repetition():
+    three = resolve((
+        Observation(Kind.CLI_AGENT, "a", path="/a", catalog_id="a",
+                    evidence=ev(Channel.FILESYSTEM) + ev(Channel.PACKAGE) + ev(Channel.RUNTIME)),
+    ))
+    once = resolve((
+        Observation(Kind.CLI_AGENT, "b", path="/b", catalog_id="b",
+                    evidence=ev(Channel.FILESYSTEM) * 3),
+    ))
+
+    assert three[0].confidence.label == "high"
+    assert once[0].confidence.label == "low"
+
+
+def test_u5_13_a_bin_symlink_binds_to_the_package_it_points_into():
+    """A package directory and the `bin` entry pointing into it are one
+    install reached two ways. They share no hash (one is a directory), no
+    inode and no normalized root, so containment is the only thing that
+    can join them -- and without it they are two assets that agree about
+    everything, which is the false split in its most ordinary form."""
+    package = Observation(
+        Kind.CLI_AGENT, "codex-cli", path="/opt/lib/node_modules/@openai/codex",
+        catalog_id="codex-cli", package_id="npm:@openai/codex", version="0.147.0",
+        evidence=ev(Channel.PACKAGE),
+    )
+    launcher = Observation(
+        Kind.CLI_AGENT, "codex-cli", path="/opt/bin/codex", catalog_id="codex-cli",
+        real_path="/opt/lib/node_modules/@openai/codex/bin/codex.js",
+        evidence=ev(Channel.FILESYSTEM),
+    )
+
+    assets = resolve((package, launcher))
+
+    assert len(assets) == 1
+    assert assets[0].confidence.label == "medium", "package and filesystem are two channels"
+
+
+def test_u5_14_a_second_install_of_one_tool_stays_separate():
+    """Containment must key on the parent install, not on its identity --
+    otherwise a vendored copy collapses into the release."""
+    release = Observation(
+        Kind.CLI_AGENT, "codex-cli", path="/opt/lib/node_modules/@openai/codex",
+        install_root="/opt/lib/node_modules/@openai", catalog_id="codex-cli",
+        version="0.147.0", evidence=ev(Channel.PACKAGE),
+    )
+    vendored = Observation(
+        Kind.CLI_AGENT, "codex-cli", path="/home/a/.codex/plugins/appserver/codex",
+        install_root="/home/a/.codex/plugins/appserver", catalog_id="codex-cli",
+        version="0.147.0-alpha.6.5", evidence=ev(Channel.FILESYSTEM),
+    )
+
+    assets = resolve((release, vendored))
+
+    assert len(assets) == 2
+    assert {a.version for a in assets} == {"0.147.0", "0.147.0-alpha.6.5"}

--- a/Discovery/adr_discovery/tests_unit/test_m6_judge.py
+++ b/Discovery/adr_discovery/tests_unit/test_m6_judge.py
@@ -1,0 +1,146 @@
+"""M6 -- judge.
+
+Precision is asserted, not just recall, so the negative cases are the
+load-bearing half. U6-09 in particular is two false positives caught on
+real machines and by no fixture.
+"""
+
+from __future__ import annotations
+
+from adr_discovery.contracts.evidence import Band, Channel
+from adr_discovery.contracts.records import Asset, Declaration, Kind, Liveness
+from adr_discovery.judge import Policy, judge
+from adr_discovery.judge.risk import credential_reach, operand_of, pinning, unattended
+
+
+def declaration(command, args=(), **kwargs):
+    return Declaration(kind=Kind.MCP_SERVER, name=kwargs.pop("name", "srv"), path="/cfg",
+                       command=command, args=tuple(args), **kwargs)
+
+
+def asset(name="srv", kind=Kind.MCP_SERVER, **kwargs):
+    return Asset(asset_id="id-" + name, kind=kind, name=name, identity=name,
+                 catalog_id=kwargs.pop("catalog_id", "srv"),
+                 confidence=Band("medium", (Channel.CONFIG,)), **kwargs)
+
+
+# ------------------------------------------------------------------ pinning
+
+
+def test_u6_01_unpinned_then_pinned():
+    assert pinning("npx", ("-y", "server-github"))[0] is False
+    assert pinning("npx", ("-y", "@modelcontextprotocol/server-github@1.4.2"))[0] is True
+
+
+def test_u6_02_a_volume_mount_is_not_an_image():
+    operand, _ = operand_of("docker", ("run", "-v", "/data:/srv", "img:tag"))
+
+    assert operand == "img:tag"
+
+
+def test_u6_03_a_registry_url_is_not_a_package():
+    operand, _ = operand_of("pip", ("install", "--index-url", "https://r/simple", "pkg"))
+
+    assert operand == "pkg"
+
+
+def test_u6_04_a_digest_is_pinned():
+    assert pinning("docker", ("run", "ghcr.io/x/y@sha256:ab34cd56"))[0] is True
+
+
+# -------------------------------------------------------------- credentials
+
+
+def test_u6_05_an_absent_env_block_means_all_not_none():
+    names, kinds = credential_reach((), env_declared=False)
+
+    assert kinds == ("inherited",)
+    assert names == ("<inherits parent environment>",)
+
+
+def test_u6_06_names_never_values():
+    names, kinds = credential_reach(("ANTHROPIC_API_KEY", "PATH"), env_declared=True)
+
+    assert names == ("ANTHROPIC_API_KEY", "PATH")
+    assert kinds == ("anthropic",)
+
+
+# ------------------------------------------------------------------- policy
+
+
+def test_u6_07_tenant_values_come_from_configuration():
+    """One world, two policies, two verdicts. A value reachable from code
+    alone cannot pass this."""
+    from dataclasses import replace
+
+    from adr_discovery.contracts.records import Risk
+
+    subject = replace(asset(), risk=Risk(destinations=("api.vendor.example",)))
+
+    ours = Policy.from_dict({"tenant_domains": ["vendor.example"]})
+    theirs = Policy.from_dict({"tenant_domains": ["corp.internal"]})
+
+    _, none_raised = judge((subject,), {}, ours)
+    _, raised = judge((subject,), {}, theirs)
+
+    assert [f.rule for f in none_raised] == []
+    assert [f.rule for f in raised] == ["third_party_destination"]
+
+
+def test_u6_08_unattended_comes_from_the_agents_own_launch():
+    """cron, a timer or a person -- the same argv is the same finding."""
+    argv = ("-p", "--dangerously-skip-permissions")
+
+    assert unattended(argv)
+    assert unattended(("--dangerously-skip-permissions",))
+    assert not unattended(("-p",)), "headless alone is not a bypass"
+
+
+# ---------------------------------------------------------------- precision
+
+
+def test_u6_09_the_two_false_positives_stay_silent():
+    from dataclasses import replace
+
+    from adr_discovery.contracts.records import Risk
+
+    # `npx eslint .` -- a shell's argv is arbitrary user text.
+    eslint = replace(
+        asset(name="eslint", kind=Kind.CLI_AGENT, catalog_id=None),
+        risk=Risk(pinned=False),
+    )
+    # A command that merely mentions a path containing "mcp".
+    mentions = replace(
+        asset(name="build", kind=Kind.CLI_AGENT, catalog_id=None),
+        risk=Risk(pinned=False),
+    )
+
+    _, findings = judge((eslint, mentions), {}, Policy())
+
+    assert findings == (), "neither was caught by the suite the first time"
+
+
+def test_u6_10_declared_is_silent_and_undeclared_is_not():
+    from dataclasses import replace
+
+    declared = asset(name="github", liveness=Liveness.RUNNING)
+    undeclared = replace(declared, asset_id="id-undeclared", flags=("undeclared",))
+
+    _, quiet = judge((declared,), {}, Policy())
+    _, loud = judge((undeclared,), {}, Policy())
+
+    assert [f.rule for f in quiet] == []
+    assert "undeclared_mcp_server" in [f.rule for f in loud]
+
+
+def test_u6_11_an_unreadable_shape_raises_nothing(world):
+    """Ambiguity resolves toward the safe verdict, and is recorded."""
+    gate = world.gate()
+    subject = asset(name="odd")
+    declarations = {subject.asset_id: declaration("some-unknown-runner", ("--weird",), name="odd")}
+
+    judged, findings = judge((subject,), declarations, Policy(), gate.ledger)
+
+    assert judged[0].risk.pinned is None
+    assert [f.rule for f in findings if f.rule == "unpinned_mcp_server"] == []
+    assert any(p.name == "judge" and p.status == "degraded" for p in gate.ledger.freeze().probes)

--- a/Discovery/adr_discovery/tests_unit/test_m7_reporter.py
+++ b/Discovery/adr_discovery/tests_unit/test_m7_reporter.py
@@ -1,0 +1,115 @@
+"""M7 -- reporter.
+
+Half of these assert on a single snapshot; the rest need two, so the
+harness stores a before and an after and diffs them the way production
+does. The empty-machine case runs first, because a module that writes
+nothing when it finds nothing is indistinguishable from one that failed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from adr_discovery.contracts.records import Asset, Kind, Risk
+from adr_discovery.contracts.snapshot import Coverage, Denied, Snapshot, Unavailable
+from adr_discovery.reporter import DifferentEndpoints, diff, to_json
+
+
+def snapshot(assets=(), hostname="host-a", coverage=None):
+    return Snapshot(hostname=hostname, username="alice", platform="darwin",
+                    timestamp="2026-08-22T00:00:00+00:00", assets=tuple(assets),
+                    coverage=coverage or Coverage())
+
+
+def asset(name="claude-code", version="2.1.3", root="/opt/x", **kwargs):
+    return Asset(asset_id=kwargs.pop("asset_id", "id-" + name), kind=Kind.CLI_AGENT,
+                 name=name, identity=name, install_root=root, version=version, **kwargs)
+
+
+def test_u7_01_a_clean_machine_still_emits_a_snapshot():
+    empty = snapshot()
+
+    document = json.loads(to_json(empty))
+
+    assert document["assets"] == []
+    assert "coverage" in document
+    assert document["schema_version"]
+
+
+def test_u7_02_asset_ids_are_unique():
+    many = [asset(name=f"t{i}", asset_id=f"id-{i}") for i in range(500)]
+
+    ids = {a.asset_id for a in many}
+
+    assert len(ids) == 500
+
+
+def test_u7_03_an_upgrade_is_one_change_not_two():
+    before = snapshot([asset(version="2.1.3")])
+    after = snapshot([asset(version="2.2.0")])
+
+    delta = diff(before, after)
+
+    assert [c.kind for c in delta.changes] == ["version_changed"]
+    assert delta.of("appeared") == () and delta.of("disappeared") == ()
+
+
+def test_u7_04_a_reinstall_is_not_a_disappearance():
+    before = snapshot([asset(root="/opt/old", asset_id="id-old")])
+    after = snapshot([asset(root="/opt/new", asset_id="id-new")])
+
+    delta = diff(before, after)
+
+    assert [c.kind for c in delta.changes] == ["reinstalled"]
+
+
+def test_u7_05_risk_moves_even_when_the_inventory_does_not():
+    """pinned -> floating is a silent regression if only membership is diffed."""
+    before = snapshot([replace(asset(), risk=Risk(pinned=True))])
+    after = snapshot([replace(asset(), risk=Risk(pinned=False))])
+
+    delta = diff(before, after)
+
+    assert [c.detail for c in delta.of("risk_delta")] == ["pinned -> floating"]
+
+
+def test_u7_06_a_surface_that_went_dark_is_a_change():
+    before = snapshot(coverage=Coverage())
+    after = snapshot(coverage=Coverage(denied=(Denied("/opt/secret", "eacces"),),
+                                       unavailable=(Unavailable("dpkg", "gone"),)))
+
+    delta = diff(before, after)
+
+    assert any("became unreadable" in c for c in delta.coverage_delta)
+    assert any("provider became unavailable" in c for c in delta.coverage_delta)
+
+
+def test_u7_07_two_endpoints_are_refused():
+    with pytest.raises(DifferentEndpoints):
+        diff(snapshot(hostname="host-a"), snapshot(hostname="host-b"))
+
+
+def test_u7_07b_cross_endpoint_is_possible_but_must_be_asked_for():
+    delta = diff(snapshot(hostname="host-a"), snapshot(hostname="host-b"),
+                 allow_cross_endpoint=True)
+
+    assert delta.endpoint == "host-b"
+
+
+def test_u7_08_fleet_fan_out_is_not_computed_on_the_endpoint():
+    document = json.loads(to_json(snapshot([asset()])))
+
+    assert not any("fleet" in key or "fan_out" in key for key in document)
+
+
+def test_u7_09_a_snapshot_round_trips():
+    original = snapshot([asset()])
+
+    document = json.loads(to_json(original))
+
+    assert document["assets"][0]["asset_id"] == "id-claude-code"
+    assert document["assets"][0]["kind"] == "cli_agent"
+    assert json.loads(to_json(original)) == document

--- a/Discovery/adr_discovery/tests_unit/test_pipeline.py
+++ b/Discovery/adr_discovery/tests_unit/test_pipeline.py
@@ -1,0 +1,88 @@
+"""The composition root, end to end over a fixture world.
+
+These assert on the seams the per-module cases cannot see: that a
+declaration and the process running it become one asset, that an
+instruction file never becomes one, and that the snapshot's coverage
+accounts for what the scan could not reach.
+"""
+
+from __future__ import annotations
+
+import json
+
+from adr_discovery.contracts.records import Kind, Liveness
+from adr_discovery.judge import Policy
+from adr_discovery.pipeline import discover
+from adr_discovery.reporter import stats, to_json
+
+
+def endpoint(world):
+    world.dir("/Users/alice")
+    world.exe("/opt/homebrew/bin/claude", "2.1.234")
+    world.file("/Users/alice/.claude/settings.json", "{}")
+    world.json("/Users/alice/work/proj/.mcp.json", {"mcpServers": {
+        "github": {"command": "npx", "args": ["-y", "server-github"]},
+        "files": {"command": "npx", "args": ["-y", "@mcp/server-filesystem@1.4.2"]},
+        "legacy": {"url": "http://legacy.example.com/sse"},
+        "broken": "not a mapping",
+    }})
+    world.file("/Users/alice/work/proj/CLAUDE.md", "# steering prose")
+    world.surface("packages", [{"manager": "npm", "name": "@anthropic-ai/claude-code",
+                                "version": "2.1.234", "path": "/opt/homebrew/bin/claude"}])
+    world.surface("processes", [{"pid": 900, "exe": "/opt/homebrew/bin/claude",
+                                 "argv": ["claude", "-p"], "ppid": 1, "user": "alice"}])
+    return world
+
+
+def test_a_binary_and_the_process_running_it_are_one_asset(world, catalog):
+    snapshot = discover(endpoint(world).gate(), catalog)
+
+    agents = [a for a in snapshot.assets if a.kind is Kind.CLI_AGENT]
+
+    assert len(agents) == 1, "the false split M5 exists to stop"
+    assert agents[0].liveness is Liveness.RUNNING
+    assert agents[0].version == "2.1.234"
+
+
+def test_an_instruction_file_becomes_inventory_without_collecting_its_body(world, catalog):
+    snapshot = discover(endpoint(world).gate(), catalog)
+
+    instructions = [a for a in snapshot.assets if a.kind is Kind.INSTRUCTIONS]
+    assert [a.install_path for a in instructions] == ["/Users/alice/work/proj/CLAUDE.md"]
+    assert "steering prose" not in to_json(snapshot)
+
+
+def test_a_malformed_record_does_not_remove_its_siblings(world, catalog):
+    snapshot = discover(endpoint(world).gate(), catalog)
+
+    servers = {a.name for a in snapshot.assets if a.kind is Kind.MCP_SERVER}
+
+    assert servers == {"github", "files", "legacy"}
+
+
+def test_findings_are_narrow(world, catalog):
+    snapshot = discover(endpoint(world).gate(), catalog, Policy())
+
+    rules = sorted(f.rule for f in snapshot.findings)
+
+    assert rules == ["plaintext_transport", "unpinned_mcp_server"]
+    assert all(f.asset_id for f in snapshot.findings)
+
+
+def test_the_snapshot_carries_its_coverage(world, catalog):
+    gate = endpoint(world).gate()
+
+    snapshot = discover(gate, catalog)
+
+    assert not snapshot.coverage.is_complete, "surfaces this fixture cannot supply must be named"
+    assert "exec_journal" in [u.provider for u in snapshot.coverage.unavailable]
+    assert snapshot.coverage.out_of_scope
+
+
+def test_an_empty_world_still_produces_a_snapshot(world, catalog):
+    snapshot = discover(world.gate(), catalog, hostname="clean-host")
+
+    assert snapshot.assets == ()
+    assert snapshot.hostname == "clean-host"
+    assert json.loads(to_json(snapshot))["coverage"]["out_of_scope"]
+    assert stats(snapshot)["asset_count"] == 0

--- a/Discovery/adr_discovery/tests_unit/test_roundtrip_and_telemetry.py
+++ b/Discovery/adr_discovery/tests_unit/test_roundtrip_and_telemetry.py
@@ -1,0 +1,80 @@
+"""Reading a snapshot back, and the one signal an endpoint cannot produce.
+
+The delta is the product, so a snapshot that can only be written is a
+snapshot that can only be filed away. And `last_used` is the join that
+turns a configured-but-never-invoked server from a threat into a cleanup
+candidate -- it comes from session telemetry, not from the filesystem.
+"""
+
+from __future__ import annotations
+
+import json
+
+from adr_discovery.contracts.records import Kind, Liveness
+from adr_discovery.pipeline import discover
+from adr_discovery.reporter import diff, from_dict, to_json
+
+
+def endpoint(world):
+    world.dir("/Users/alice")
+    world.binary("/opt/homebrew/bin/claude", "#!/bin/sh\necho 2.1.234\n")
+    world.surface("packages", [{"manager": "npm", "name": "@anthropic-ai/claude-code",
+                                "version": "2.1.234", "path": "/opt/homebrew/bin/claude"}])
+    world.json("/Users/alice/proj/.mcp.json", {"mcpServers": {
+        "github": {"command": "npx", "args": ["-y", "server-github"]}}})
+    return world
+
+
+def test_a_snapshot_survives_the_round_trip(world, catalog):
+    original = discover(endpoint(world).gate(), catalog, hostname="host-a")
+
+    restored = from_dict(json.loads(to_json(original)))
+
+    assert restored.hostname == original.hostname
+    assert len(restored.assets) == len(original.assets)
+    assert {a.asset_id for a in restored.assets} == {a.asset_id for a in original.assets}
+    assert {a.kind for a in restored.assets} == {a.kind for a in original.assets}
+    assert restored.coverage.out_of_scope == original.coverage.out_of_scope
+
+
+def test_a_round_tripped_snapshot_diffs_cleanly_against_itself(world, catalog):
+    """Two scans of an unchanged machine must produce no delta, which is a
+    statement about `asset_id` holding still through serialization."""
+    original = discover(endpoint(world).gate(), catalog, hostname="host-a")
+    restored = from_dict(json.loads(to_json(original)))
+
+    delta = diff(restored, original)
+
+    assert delta.is_empty, [c.kind for c in delta.changes]
+
+
+def test_a_real_change_survives_serialization(world, catalog):
+    before = discover(endpoint(world).gate(), catalog, hostname="host-a")
+    world.binary("/opt/homebrew/bin/claude", "#!/bin/sh\necho 2.2.0\n")
+    world.surface("packages", [{"manager": "npm", "name": "@anthropic-ai/claude-code",
+                                "version": "2.2.0", "path": "/opt/homebrew/bin/claude"}])
+    after = discover(world.gate(), catalog, hostname="host-a")
+
+    delta = diff(from_dict(json.loads(to_json(before))), after)
+
+    assert [c.kind for c in delta.of("version_changed")] == ["version_changed"]
+    assert delta.of("appeared") == () and delta.of("disappeared") == ()
+
+
+def test_telemetry_supplies_last_used(world, catalog):
+    snapshot = discover(endpoint(world).gate(), catalog,
+                        telemetry={"claude-code": "2026-08-21T09:12:00+00:00"})
+
+    (agent,) = [a for a in snapshot.assets if a.kind is Kind.CLI_AGENT]
+    assert agent.last_used == "2026-08-21T09:12:00+00:00"
+
+
+def test_configured_but_never_invoked_stays_distinct(world, catalog):
+    """A declared server with no telemetry is a cleanup candidate, not a
+    threat -- and the two must not look the same in a snapshot."""
+    snapshot = discover(endpoint(world).gate(), catalog,
+                        telemetry={"claude-code": "2026-08-21T09:12:00+00:00"})
+
+    (server,) = [a for a in snapshot.assets if a.kind is Kind.MCP_SERVER]
+    assert server.liveness is Liveness.DECLARED_ONLY
+    assert server.last_used is None


### PR DESCRIPTION
Adds focused tests for M1-M7, import boundaries, cross-cutting privacy and coverage behavior, pipeline composition, identity, and telemetry.\n\nStack: 13/14. Depends on discovery-root-files.\n\nValidation: 218 tests passed; Ruff passed.