### PR TITLE
feat(discovery): integrate pipeline and CLI

### DIFF
--- a/Discovery/adr_discovery/README.md
+++ b/Discovery/adr_discovery/README.md
@@ -8,15 +8,38 @@ This is Plane A of ADR Discovery: the endpoint collector. It is standard-library
 
 ## Status
 
-This README is the specification for the collector. The implementation is not in this repository yet — read the module boundaries and the code layout below as the target, not as a description of code you can import today.
+The endpoint collector is implemented in this repository. Its seven-stage pipeline, typed contracts, coverage ledger, evidence ladder, resolver, policy judge, snapshot/delta reporter and command-line entry point are usable today. The implementation is standard-library-only; `pytest` and `ruff` are development dependencies only.
 
 | | |
 | --- | --- |
-| **Design of record** | `adr-discovery-design.html` — the full argument, the module contracts, and the evidence behind each decision |
-| **Measured against** | An existing ~4,900-line pipeline whose behaviour this design responds to |
-| **In this repository** | This specification, and the test plan in [../tests/README.md](../tests/README.md) |
+| **Design of record** | `adr-discovery-design.html` — the full argument, module contracts and complete target corpus |
+| **Implementation** | This package: M1–M7, the cross-cutting catalog/redaction/coverage concerns, and the `adr-discovery` CLI |
+| **Verification** | The fast module and pipeline suite under `tests_unit/`, plus the black-box endpoint harness in [../tests/README.md](../tests/README.md) |
+| **Current maturity** | Core architecture complete; production source coverage and the three-OS golden-endpoint corpus remain incomplete |
 
 The rewrite exists because the old layout had no boundary a linter could check. Five probes each carried their own copy of `PROJECT_ROOTS`; a filename match was enough to become an asset; and a suite of 490 checks derived from the catalog passed while real placement failures went undetected. The sections below are organized around not repeating that.
+
+### Current limitations
+
+- Execution journals are modeled but no production ESF, eBPF or ETW/Sysmon collector is bundled. Their absence is reported in coverage.
+- DNS-cache enumeration is unavailable on the current macOS and Linux providers. Live outbound TCP connections are still collected.
+- Listening sockets are enumerated, but protocol-level HTTP, MCP and model-runtime verification is not implemented.
+- WSL, containers, remote/cloud agents, scheduled agents, account identity and code-signature collection are not implemented.
+- Fleet aggregation, fan-out and trend tracking belong to the central plane and are not part of this endpoint package.
+- The black-box harness is operational for a subset of the manifest. Vendor applications, authenticated sessions, services and model-weight scenarios still need additional install recipes and golden guests.
+- `coverage.out_of_scope` still names instruction files and hooks even though the collector now inventories them. The snapshot vocabulary must be corrected before treating that field as authoritative.
+
+### Run it
+
+From the repository root:
+
+```sh
+uv run adr-discovery --dry-run --json
+uv run adr-discovery --dry-run --explain
+UV_CACHE_DIR=/tmp/adr-discovery-uv-cache uv run pytest -q
+```
+
+A scan that encounters an unreadable, unavailable or truncated surface still emits a snapshot and exits with status `2`; that status means partial coverage, not a failed scan.
 
 ## What it has to find
 
@@ -29,12 +52,11 @@ Four targets. They are not variations on one search — each lives somewhere dif
 | **MCP servers** — stdio, SSE, HTTP, containerized | Config files across a dozen host applications, policy stores, bundles | A declaration, and sometimes a running child process. Often nothing on disk at all |
 | **Skills** — skills, slash commands, output styles, plugins | Agent state directories, plugins, repositories | A file in a structure an agent knows how to load |
 
-### Deliberately out of scope
+### Programmable surfaces and deliberate exclusions
 
-Two categories are excluded on purpose rather than by omission, and both are named in `coverage.out_of_scope` so a reader can tell a clean machine from an unasked question.
+The implementation inventories programmable surfaces that change what an agent can do: skills, commands, output styles, plugins, agent definitions, hooks and instruction files. It records structure and allowlisted metadata, never instruction or skill bodies. This is broader than the original design decision that treated hooks and instruction files only as repository markers.
 
-- **Instruction and rules files** — `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, Cursor and Windsurf rules. These are prose that steers an agent, not software that runs. Their *filenames* remain markers that locate a repository where an agent works; no instruction file becomes an asset.
-- **Scripts the agent executes** — hooks, and the mechanisms that start an agent unattended: launchd plists, cron entries, systemd timers, scheduled tasks, login items. Discovery reports the agent, not the mechanism that starts it.
+Scheduling mechanisms remain deliberately out of scope: launchd plists, cron entries, systemd timers, scheduled tasks and login items do not become assets. The agent they launch may still be found through the process table or an optional execution journal.
 
 ## Architecture
 
@@ -84,7 +106,7 @@ The last two sources answer a different question from the first four. Listening 
 | M4 | Identifier | Deciding what a candidate actually is, and how sure | Renamed tools vanishing; decoys becoming assets |
 | M5 | Resolver | Merging observations into assets; confidence; liveness | False splits and false merges |
 | M6 | Judge | Risk verdicts, sanction state, findings | Findings the operator learns to dismiss |
-| M7 | Reporter | Snapshot, coverage, delta, fleet drift | A partial inventory reading as a complete one |
+| M7 | Reporter | Endpoint snapshot, coverage and delta | A partial inventory reading as a complete one |
 
 Three concerns cut across rather than sitting in the line: **C1 Catalog** is data, not code, so the landscape's weekly churn is not on the release train. **C2 Redaction** happens inside whichever stage touches risky text, never as a pass at the end. **C3 Coverage** is written by every stage, because every stage can fail to see something.
 
@@ -109,17 +131,19 @@ adr_discovery/
 │       └── darwin.py · linux.py · windows.py
 │
 ├── enumerator/           M2 · where to look
-│   ├── sources/            one file per source above — add a source, add a file
-│   │   ├── packages.py · appreg.py · kernel.py · appstate.py
+│   ├── sources/            registry, filesystem, state and runtime sources
+│   │   ├── registries.py   packages · applications · kernel
+│   │   ├── appstate.py · binaries.py · modelstores.py
 │   │   ├── network.py      outbound connections · resolver cache
-│   │   └── execjournal.py  ESF · eBPF · ETW/Sysmon — optional
+│   │   └── execjournal.py  optional historical execution source
 │   ├── sweep.py            marker traversal, breadth-ordered, under the shared budget
 │   ├── markers.py          the marker set, as data
 │   └── roots.py            priority roots — one definition
 │
 ├── extractor/            M3 · what is declared
 │   ├── isolate.py          the per-record try boundary, written once
-│   └── formats/            json.py · toml.py · yaml.py · plist.py · workflow.py
+│   ├── surfaces.py         skills · commands · plugins · agent definitions
+│   └── formats/            JSON · TOML · plist · guarded YAML · front matter · workflows
 │
 ├── identifier/           M4 · what it really is
 │   ├── ladder.py           provenance → content → behaviour → convention, stop at proof
@@ -163,11 +187,12 @@ One normalized record per asset, keyed so policy can act on it and a delta can t
 asset_id      stable across version upgrades, store rebuilds, credential rotation
 kind          cli_agent · app · ai_browser · model_runtime · model_weights
               extension · mcp_server · mcp_bundle · skill · command
-              plugin · output_style · agent_definition · ci_agent · cloud_agent
+              plugin · output_style · agent_definition · hook · instructions
+              ci_agent · cloud_agent · agent_platform
 identity      catalog id, or a content-derived identity for the uncatalogued
               name · vendor · version · install_path · install_root · install_method
 owner         a person, or "system" — never whoever ran the scan
-location      local · wsl:<distro> · container · remote:<host>
+location      local today; the schema reserves wsl:<distro> · container · remote:<host>
 evidence[]    {stage, channel, path, proof, confidence}   ← why we believe it
 verification  how identity was established: provenance · content · behaviour
 confidence    derived from channel count, reported as a band
@@ -204,7 +229,7 @@ This runs on employee laptops in a jurisdictionally messy fleet. The constraints
 - **Applied at collection**, inside the stage that touches the risky text — not as a filter afterwards, which is something a new probe can be added behind.
 - **Both directions are measured.** A leak is obvious; over-redaction is not. A dropped flag name is an undetected permission bypass, so signal retention is measured alongside leak count.
 - **Personal paths are denied centrally**, enforced at M1, so a stage added tomorrow inherits it.
-- **`--dry-run --explain` prints exactly what would leave the machine**, per stage and per field. The collector is open source; an employee can read it and check.
+- **`--explain` prints the collection and redaction rules.** `--dry-run --json` emits the resulting snapshot without writing it to disk. A future explain mode should join these into a per-stage, per-field payload trace.
 
 The tension worth naming: M4's content and provenance evidence is stronger than name matching precisely because it looks harder at the machine. The line held here is *hash and identify, never transmit content; report that a credential is reachable, never which one it is.*
 
@@ -228,24 +253,24 @@ The fast per-commit suite is a separate instrument, documented alongside it: syn
 
 The two are complementary and neither replaces the other. The fixture suite has a perfect oracle — it built the machine — but can only contain situations somebody imagined, so it catches regressions. The VM run has real input nobody predicted but a slower, costlier oracle, so it discovers defects. Every defect a VM run finds should be reduced to a fixture case, which is the intended flow of work between them.
 
-Automating that VM run — provision, install a manifest, scan, score, and replay the scoring over recorded runs without touching a VM — is in progress under `tests/`.
+The harness under `tests/` can validate manifests, synthesize and replay recorded runs, provision through its current guest drivers, and generate JSON and HTML scorecards. Only part of the install manifest currently has executable recipes; see [HARNESS.md](../tests/HARNESS.md) for current counts and known guest limitations.
 
 Unit tests mirror the package tree — one directory per module, importing only that module. The arrangement is the assertion: a module that cannot be tested without standing up three others does not have a boundary, whatever the directory listing says.
 
-## Build order
+## Implementation progress
 
-Sequenced by how much of the measured failure each step removes, not by module number.
+The original build order is now a progress checklist.
 
-| Step | Work | Closes |
+| Status | Work | Notes |
 | --- | --- | --- |
-| 1 | Extract every hard-coded root into M2; single sweep, single budget, boundaries reported | 4 of 5 in-scope placement misses; duplicated tuples in five files |
-| 2 | Kernel and registry sources; all browser profiles | Wrong-path attribution; extensions on non-default profiles; provenance for M4 |
-| 3 | M4 evidence ladder with verified version shapes; catalog gains its `proofs` block | The fabricated asset; the renamed agent; missing versions |
-| 4 | Content identity in M5; attributes bind to installs | The Ollama split, and its whole class |
-| 5 | Coverage ledger as a first-class snapshot field | Every silent boundary, including the ones not yet found |
-| 6 | Golden-endpoint corpus and a placement matrix per target, in CI | The circularity that let all of the above pass |
+| Complete | Single M2 sweep, priority roots, shared budget and reported boundaries | Removes duplicated root lists and makes partial traversal visible |
+| Partial | Kernel, package/application registry and per-profile application-state sources | Core providers exist; DNS history, execution journals and several platform-specific surfaces remain |
+| Complete | Evidence ladder, verified version shapes and schema-validated catalog proofs | Convention alone never concludes identity |
+| Complete | Content/installation identity, conflict-safe merging and stable asset IDs | Covered by resolver and delta regressions |
+| Complete | First-class coverage, privacy constructors, snapshot round trip and endpoint delta | Partial scans are emitted and return a distinct CLI status |
+| Partial | Golden-endpoint corpus and placement matrices | Scorer and subset recipes exist; full macOS/Linux/Windows execution remains |
 
-Steps 1 and 2 are mechanical and remove most of the measured miss rate. Step 3 changes the module's character and is the one to be careful with: it must not cost precision.
+The next work should prioritize production protocol verification and source coverage, then finish the golden-endpoint recipes. More fixture tests alone cannot establish real precision or recall.
 
 ## License
 

--- a/Discovery/adr_discovery/README.md
+++ b/Discovery/adr_discovery/README.md
@@ -146,8 +146,8 @@ adr_discovery/
 │   └── formats/            JSON · TOML · plist · guarded YAML · front matter · workflows
 │
 ├── identifier/           M4 · what it really is
-│   ├── ladder.py           provenance → content → behaviour → convention, stop at proof
-│   ├── verify.py           run the version probe, then check the shape of the answer
+│   ├── ladder.py           provenance → content → convention, stop at proof
+│   ├── verify.py           compatibility refusal for executable probes
 │   └── openworld.py        score the uncatalogued on properties, never on names
 │
 ├── resolver/             M5 · one thing, one asset
@@ -194,14 +194,14 @@ identity      catalog id, or a content-derived identity for the uncatalogued
 owner         a person, or "system" — never whoever ran the scan
 location      local today; the schema reserves wsl:<distro> · container · remote:<host>
 evidence[]    {stage, channel, path, proof, confidence}   ← why we believe it
-verification  how identity was established: provenance · content · behaviour
+verification  how identity was established: provenance · content
 confidence    derived from channel count, reported as a band
 liveness      running · installed · declared_only
 last_used     from Sensor session telemetry
 risk          {pinned, factors[], credential_kinds[], env_names[], …}
 ```
 
-`evidence` makes every claim checkable, and `verification` says which rung of the ladder established identity — so a reader can tell a package-owned binary from a filename that looked right.
+`evidence` makes every claim checkable, and `verification` says which rung of the ladder established identity — so a reader can tell a package-owned binary from a filename that looked right. Discovered executables are never run. OS inventory helpers use fixed absolute paths through a separate bounded-output interface; they cannot be selected through the scanner's inherited `PATH`.
 
 ### Coverage travels with it
 

--- a/Discovery/adr_discovery/__init__.py
+++ b/Discovery/adr_discovery/__init__.py
@@ -1,0 +1,15 @@
+"""ADR Discovery -- the endpoint collector.
+
+Find the AI binaries, agents, MCP servers and skills present on an employee
+endpoint, accurately enough that a security team can act on the answer and
+honestly enough that they can tell when it is incomplete.
+"""
+
+from __future__ import annotations
+
+from .contracts.snapshot import SCHEMA_VERSION, Coverage, Snapshot
+from .pipeline import discover
+from .reporter import diff, to_dict, to_json
+
+__version__ = "0.2.0"
+__all__ = ["discover", "diff", "to_dict", "to_json", "Snapshot", "Coverage", "SCHEMA_VERSION"]

--- a/Discovery/adr_discovery/cli.py
+++ b/Discovery/adr_discovery/cli.py
@@ -14,6 +14,7 @@ import os
 import platform
 import socket
 import sys
+import unicodedata
 from datetime import datetime, timezone
 
 from .catalog.load import CatalogError
@@ -29,6 +30,7 @@ from .world.gate import Gate
 from .world.platform import for_host
 
 EXIT_OK, EXIT_ERROR, EXIT_PARTIAL = 0, 1, 2
+MAX_JSON_INPUT = 16 * 1024 * 1024
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -45,7 +47,6 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--allow-cross-endpoint", action="store_true",
                    help="permit a diff between two different hosts")
     p.add_argument("--max-entries", type=int, default=200_000, help="shared sweep ceiling")
-    p.add_argument("--no-subprocess", action="store_true", help="refuse the behaviour rung")
     return p
 
 
@@ -70,13 +71,19 @@ def main(argv: list[str] | None = None) -> int:
 
     policy = Policy()
     if args.policy:
-        with open(args.policy, encoding="utf-8") as fh:
-            policy = Policy.from_dict(json.load(fh))
+        try:
+            policy = Policy.from_dict(_load_json_mapping(args.policy, "policy"))
+        except (OSError, ValueError, TypeError) as exc:
+            print(f"cannot read policy: {_terminal(exc)}", file=sys.stderr)
+            return EXIT_ERROR
 
     telemetry = None
     if args.telemetry:
-        with open(args.telemetry, encoding="utf-8") as fh:
-            telemetry = json.load(fh)
+        try:
+            telemetry = _telemetry(_load_json_mapping(args.telemetry, "telemetry"))
+        except (OSError, ValueError, TypeError) as exc:
+            print(f"cannot read telemetry: {_terminal(exc)}", file=sys.stderr)
+            return EXIT_ERROR
 
     gate = Gate(
         root=args.root,
@@ -84,7 +91,6 @@ def main(argv: list[str] | None = None) -> int:
         budget=Budget(max_entries=args.max_entries),
         providers=for_host() if args.root == "/" else None,
         env=dict(os.environ),
-        allow_subprocess=not args.no_subprocess,
     )
 
     snapshot = discover(
@@ -102,10 +108,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.diff:
         try:
-            with open(args.diff, encoding="utf-8") as fh:
-                previous = from_dict(json.load(fh))
-        except (OSError, ValueError, KeyError) as exc:
-            print(f"cannot read {args.diff}: {exc}", file=sys.stderr)
+            previous = from_dict(_load_json_mapping(args.diff, "snapshot"))
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            print(f"cannot read {_terminal(args.diff)}: {_terminal(exc)}", file=sys.stderr)
             return EXIT_ERROR
         try:
             _delta(diff(previous, snapshot, args.allow_cross_endpoint))
@@ -114,11 +119,13 @@ def main(argv: list[str] | None = None) -> int:
             return EXIT_ERROR
 
     if not args.dry_run:
-        os.makedirs(args.output_dir, exist_ok=True)
-        target = os.path.join(args.output_dir, f"snapshot-{snapshot.timestamp.replace(':', '')}.json")
-        with open(target, "w", encoding="utf-8") as fh:
-            fh.write(to_json(snapshot))
-        print(f"\nwrote {target}", file=sys.stderr)
+        filename = f"snapshot-{snapshot.timestamp.replace(':', '')}.json"
+        try:
+            target = _write_private(args.output_dir, filename, to_json(snapshot))
+        except OSError as exc:
+            print(f"cannot write snapshot: {_terminal(exc)}", file=sys.stderr)
+            return EXIT_ERROR
+        print(f"\nwrote {_terminal(target)}", file=sys.stderr)
 
     # A scan that could not see everything says so in its exit code, because
     # a partial inventory must never be indistinguishable from a clean one.
@@ -126,32 +133,103 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _delta(delta) -> None:
-    print(f"\ndelta vs the previous snapshot of {delta.endpoint}")
+    print(f"\ndelta vs the previous snapshot of {_terminal(delta.endpoint)}")
     if delta.is_empty:
         print("  no change")
         return
     for change in delta.changes:
-        detail = f"  ({change.detail})" if change.detail else ""
-        print(f"  {change.kind:<16} {change.name}{detail}")
+        detail = f"  ({_terminal(change.detail)})" if change.detail else ""
+        print(f"  {_terminal(change.kind):<16} {_terminal(change.name)}{detail}")
     for note in delta.coverage_delta:
-        print(f"  coverage         {note}")
+        print(f"  coverage         {_terminal(note)}")
 
 
 def _summary(snapshot) -> None:
     counts = stats(snapshot)
-    print(f"{snapshot.hostname} · {snapshot.platform} · catalog {snapshot.catalog_version}")
+    print(f"{_terminal(snapshot.hostname)} · {_terminal(snapshot.platform)} · "
+          f"catalog {_terminal(snapshot.catalog_version)}")
     print(f"  assets {counts['asset_count']} · findings {counts['finding_count']} · "
           f"review queue {counts['review_queue_count']} · coverage gaps {counts['coverage_gaps']}")
     for asset in snapshot.assets:
-        version = f" {asset.version}" if asset.version else ""
-        print(f"    {asset.kind.value:<14} {asset.name}{version}  [{asset.liveness.value}, "
+        version = f" {_terminal(asset.version)}" if asset.version else ""
+        print(f"    {asset.kind.value:<14} {_terminal(asset.name)}{version}  [{asset.liveness.value}, "
               f"{asset.confidence.label} confidence]")
     for finding in snapshot.findings:
-        print(f"  ! {finding.severity:<7} {finding.rule}: {finding.summary}")
+        print(f"  ! {_terminal(finding.severity):<7} {_terminal(finding.rule)}: "
+              f"{_terminal(finding.summary)}")
     cov = snapshot.coverage
     if not cov.is_complete:
         print(f"  coverage: {len(cov.denied)} denied · {len(cov.unavailable)} unavailable · "
               f"{len(cov.boundaries_hit)} boundaries · {len(cov.truncated)} truncated")
+
+
+def _load_json_mapping(path: str, label: str) -> dict:
+    """Load one bounded JSON object; optional CLI inputs are untrusted too."""
+    with open(path, "rb") as fh:
+        raw = fh.read(MAX_JSON_INPUT + 1)
+    if len(raw) > MAX_JSON_INPUT:
+        raise ValueError(f"{label} exceeds {MAX_JSON_INPUT} bytes")
+    try:
+        document = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(f"{label} is not valid JSON: {exc}") from exc
+    if not isinstance(document, dict):
+        raise ValueError(f"{label} root must be an object")
+    return document
+
+
+def _telemetry(document: dict) -> dict[str, str]:
+    if not all(isinstance(key, str) and isinstance(value, str) for key, value in document.items()):
+        raise ValueError("telemetry must map strings to strings")
+    return document
+
+
+def _write_private(output_dir: str, filename: str, text: str) -> str:
+    """Create a new private snapshot without following a target symlink."""
+    if os.path.basename(filename) != filename:
+        raise OSError("snapshot filename must not contain a directory")
+    os.makedirs(output_dir, mode=0o700, exist_ok=True)
+    absolute = os.path.abspath(output_dir)
+    if os.path.islink(absolute):
+        raise OSError("output directory must not be a symlink")
+
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    directory_fd = os.open(absolute, directory_flags)
+    try:
+        before = os.fstat(directory_fd)
+        current = os.stat(absolute, follow_symlinks=False)
+        if (before.st_dev, before.st_ino) != (current.st_dev, current.st_ino):
+            raise OSError("output directory changed during validation")
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        if os.open in os.supports_dir_fd:
+            fd = os.open(filename, flags, 0o600, dir_fd=directory_fd)
+        else:  # Windows has no dir_fd variant; O_EXCL still prevents clobbering.
+            fd = os.open(os.path.join(absolute, filename), flags, 0o600)
+        try:
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fd = -1
+                fh.write(text)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+    finally:
+        os.close(directory_fd)
+    return os.path.join(output_dir, filename)
+
+
+def _terminal(value: object) -> str:
+    """Render untrusted text without terminal control or bidi characters."""
+    out = []
+    for char in str(value):
+        if unicodedata.category(char).startswith("C"):
+            code = ord(char)
+            out.append(f"\\x{code:02x}" if code <= 0xFF else f"\\u{code:04x}")
+        else:
+            out.append(char)
+    return "".join(out)
 
 
 if __name__ == "__main__":

--- a/Discovery/adr_discovery/cli.py
+++ b/Discovery/adr_discovery/cli.py
@@ -1,0 +1,158 @@
+"""Argument parsing and exit codes. Nothing else.
+
+Everything this file knows how to do is delegated; keeping it thin is what
+lets `discover()` be called from a test, a fixture harness or another
+program without going through a command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import platform
+import socket
+import sys
+from datetime import datetime, timezone
+
+from .catalog.load import CatalogError
+from .catalog.load import loads as load_catalog
+from .coverage.ledger import Ledger
+from .judge import Policy
+from .pipeline import discover
+from .redact import rules as redact
+from .reporter import diff, from_dict, stats, to_json
+from .reporter.delta import DifferentEndpoints
+from .world.budget import Budget
+from .world.gate import Gate
+from .world.platform import for_host
+
+EXIT_OK, EXIT_ERROR, EXIT_PARTIAL = 0, 1, 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="adr-discovery", description="Inventory the AI tools on this endpoint.")
+    p.add_argument("--root", default="/", help="scan a fixture tree instead of the live machine")
+    p.add_argument("--json", action="store_true", help="print the whole snapshot as JSON")
+    p.add_argument("--dry-run", action="store_true", help="scan and print, write nothing")
+    p.add_argument("--explain", action="store_true", help="print exactly what would leave the machine")
+    p.add_argument("--output-dir", default="./output", help="where the snapshot lands")
+    p.add_argument("--policy", help="tenant policy JSON: approved, forbidden, tenant_domains")
+    p.add_argument("--telemetry", help="JSON mapping catalog id to last-used timestamp")
+    p.add_argument("--diff", metavar="SNAPSHOT",
+                   help="compare this scan against a previous snapshot and print the delta")
+    p.add_argument("--allow-cross-endpoint", action="store_true",
+                   help="permit a diff between two different hosts")
+    p.add_argument("--max-entries", type=int, default=200_000, help="shared sweep ceiling")
+    p.add_argument("--no-subprocess", action="store_true", help="refuse the behaviour rung")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.explain:
+        print("adr-discovery would collect:")
+        for line in redact.explain():
+            print(f"  - {line}")
+        print()
+        if args.dry_run and not args.json:
+            return EXIT_OK
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    try:
+        with open(os.path.join(here, "catalog", "catalog.json"), encoding="utf-8") as fh:
+            catalog = load_catalog(fh.read())
+    except (OSError, CatalogError) as exc:
+        print(f"catalog unusable: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    policy = Policy()
+    if args.policy:
+        with open(args.policy, encoding="utf-8") as fh:
+            policy = Policy.from_dict(json.load(fh))
+
+    telemetry = None
+    if args.telemetry:
+        with open(args.telemetry, encoding="utf-8") as fh:
+            telemetry = json.load(fh)
+
+    gate = Gate(
+        root=args.root,
+        ledger=Ledger(),
+        budget=Budget(max_entries=args.max_entries),
+        providers=for_host() if args.root == "/" else None,
+        env=dict(os.environ),
+        allow_subprocess=not args.no_subprocess,
+    )
+
+    snapshot = discover(
+        gate, catalog, policy, telemetry,
+        hostname=socket.gethostname(),
+        username=getpass.getuser(),
+        platform_name=platform.system().lower(),
+        timestamp=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+
+    if args.json:
+        print(to_json(snapshot))
+    else:
+        _summary(snapshot)
+
+    if args.diff:
+        try:
+            with open(args.diff, encoding="utf-8") as fh:
+                previous = from_dict(json.load(fh))
+        except (OSError, ValueError, KeyError) as exc:
+            print(f"cannot read {args.diff}: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+        try:
+            _delta(diff(previous, snapshot, args.allow_cross_endpoint))
+        except DifferentEndpoints as exc:
+            print(f"\n{exc}", file=sys.stderr)
+            return EXIT_ERROR
+
+    if not args.dry_run:
+        os.makedirs(args.output_dir, exist_ok=True)
+        target = os.path.join(args.output_dir, f"snapshot-{snapshot.timestamp.replace(':', '')}.json")
+        with open(target, "w", encoding="utf-8") as fh:
+            fh.write(to_json(snapshot))
+        print(f"\nwrote {target}", file=sys.stderr)
+
+    # A scan that could not see everything says so in its exit code, because
+    # a partial inventory must never be indistinguishable from a clean one.
+    return EXIT_OK if snapshot.coverage.is_complete else EXIT_PARTIAL
+
+
+def _delta(delta) -> None:
+    print(f"\ndelta vs the previous snapshot of {delta.endpoint}")
+    if delta.is_empty:
+        print("  no change")
+        return
+    for change in delta.changes:
+        detail = f"  ({change.detail})" if change.detail else ""
+        print(f"  {change.kind:<16} {change.name}{detail}")
+    for note in delta.coverage_delta:
+        print(f"  coverage         {note}")
+
+
+def _summary(snapshot) -> None:
+    counts = stats(snapshot)
+    print(f"{snapshot.hostname} · {snapshot.platform} · catalog {snapshot.catalog_version}")
+    print(f"  assets {counts['asset_count']} · findings {counts['finding_count']} · "
+          f"review queue {counts['review_queue_count']} · coverage gaps {counts['coverage_gaps']}")
+    for asset in snapshot.assets:
+        version = f" {asset.version}" if asset.version else ""
+        print(f"    {asset.kind.value:<14} {asset.name}{version}  [{asset.liveness.value}, "
+              f"{asset.confidence.label} confidence]")
+    for finding in snapshot.findings:
+        print(f"  ! {finding.severity:<7} {finding.rule}: {finding.summary}")
+    cov = snapshot.coverage
+    if not cov.is_complete:
+        print(f"  coverage: {len(cov.denied)} denied · {len(cov.unavailable)} unavailable · "
+              f"{len(cov.boundaries_hit)} boundaries · {len(cov.truncated)} truncated")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Discovery/adr_discovery/pipeline.py
+++ b/Discovery/adr_discovery/pipeline.py
@@ -1,0 +1,236 @@
+"""The composition root.
+
+The only file in the package that imports more than one stage, which is
+what keeps execution order an explicit statement here rather than an
+emergent property of the import graph.
+
+    M2 enumerate -> M3 extract -> M4 identify -> M5 resolve -> M6 judge -> M7 report
+
+Every stage takes its input type and returns its output type. Coverage
+travels beside the data the whole way and is frozen once, at the end.
+"""
+
+from __future__ import annotations
+
+from .catalog.load import EMPTY as EMPTY_CATALOG
+from .catalog.load import Catalog
+from .contracts.evidence import Channel, Evidence
+from .contracts.records import (
+    Asset,
+    Candidate,
+    Declaration,
+    Kind,
+    Liveness,
+    Observation,
+    ReviewItem,
+)
+from .contracts.snapshot import Snapshot
+from .enumerator import enumerate_candidates
+from .extractor import extract
+from .extractor.surfaces import surface_for
+from .identifier import content_hash, identify, is_reviewable, score, signals_for
+from .judge import EMPTY as EMPTY_POLICY
+from .judge import Policy, judge
+from .resolver import resolve
+from .world.gate import Gate
+
+CATALOG_RESOURCE = "catalog/catalog.json"
+
+#: Candidate kinds that describe a *surface to read* rather than a thing.
+#: A marker directory may be one too -- skills/, commands/, agents/ and
+#: friends are records in directory form.
+CONFIG_KINDS = frozenset({"marker_file", "marker_dir", "instruction_file", "shell_profile"})
+#: Candidate kinds that never become an asset (§1).
+LOCATOR_KINDS = frozenset({"locator"})
+
+
+def discover(
+    gate: Gate,
+    catalog: Catalog | None = None,
+    policy: Policy = EMPTY_POLICY,
+    telemetry: dict[str, str] | None = None,
+    hostname: str = "unknown",
+    username: str = "unknown",
+    platform_name: str = "unknown",
+    timestamp: str = "",
+) -> Snapshot:
+    """One scan, one snapshot. Emitted even when nothing is found."""
+    catalog = catalog if catalog is not None else EMPTY_CATALOG
+    ledger = gate.ledger
+
+    # -- M2 ------------------------------------------------------------
+    candidates = enumerate_candidates(gate)
+
+    # -- M3 ------------------------------------------------------------
+    declarations: list[tuple[Candidate, Declaration]] = []
+    for candidate in candidates:
+        if candidate.kind not in CONFIG_KINDS:
+            continue
+        if candidate.kind == "marker_dir" and surface_for(candidate.path) is None:
+            continue  # a repository marker locates work; it declares nothing
+        extraction = extract(gate, candidate)
+        for error in extraction.errors:
+            ledger.probe("extractor", "degraded", f"{error.path}: {error.reason}")
+        if extraction.declared and len(extraction.declarations) < extraction.declared:
+            ledger.probe(
+                "extractor", "degraded",
+                f"{candidate.path}: {len(extraction.declarations)} of {extraction.declared} records read",
+            )
+        for declaration in extraction.declarations:
+            declarations.append((candidate, declaration))
+
+    # -- M4 ------------------------------------------------------------
+    observations: list[Observation] = []
+    review: list[ReviewItem] = []
+
+    for candidate in candidates:
+        if candidate.kind in CONFIG_KINDS | LOCATOR_KINDS:
+            continue
+        verdict = identify(gate, candidate, catalog)
+        if verdict.is_concluded and verdict.kind is not None:
+            observations.append(_observation_from(gate, candidate, verdict))
+            continue
+        value, fired = score(candidate, signals_for(candidate))
+        # Network intent is uniquely strong operational evidence even though
+        # its generic open-world score remains below the multi-signal cutoff.
+        if is_reviewable(value) or "network_intent" in fired:
+            review.append(
+                ReviewItem(path=candidate.path, score=value, signals=fired, evidence=verdict.evidence)
+            )
+
+    for candidate, declaration in declarations:
+        observations.append(_observation_from_declaration(candidate, declaration))
+
+    # -- M5 ------------------------------------------------------------
+    assets = resolve(tuple(observations), telemetry, ledger)
+    assets = _mark_undeclared(assets, declarations)
+
+    # -- M6 ------------------------------------------------------------
+    by_asset = _declarations_by_asset(assets, declarations)
+    assets, findings = judge(assets, by_asset, policy, ledger)
+
+    # -- M7 ------------------------------------------------------------
+    return Snapshot(
+        hostname=hostname,
+        username=username,
+        platform=platform_name,
+        timestamp=timestamp,
+        assets=assets,
+        findings=findings,
+        review_queue=tuple(review),
+        coverage=ledger.freeze(),
+        catalog_version=catalog.version,
+    )
+
+
+# --------------------------------------------------------------- adapters
+
+
+def _observation_from(gate, candidate: Candidate, verdict) -> Observation:
+    # The real path and inode are the strong merge keys. Without them a
+    # binary and the process running it are two rows that agree about
+    # everything and merge on nothing -- the false split M5 exists to stop.
+    stat = gate.stat(candidate.path)
+    real_path = stat.value.real_path if stat.ok else None
+    inode = stat.value.inode if stat.ok else None
+    # Same bytes, wherever they sit: the strongest merge key, and the only
+    # one that survives a copy to a second path. Computed for identified
+    # files only, so the cost is bounded by what we already believe in.
+    digest = content_hash(gate, candidate.path) if stat.ok and _is_file(stat.value) else None
+    detail = dict(candidate.detail)
+    # Raw argv is collection-only. M6 receives the derived facts it needs,
+    # while a snapshot can never accidentally serialize prompts or tokens.
+    detail.pop("argv", None)
+    detail["name"] = verdict.name
+    detail["vendor"] = verdict.vendor
+    if candidate.source.startswith("package:"):
+        detail["install_method"] = candidate.source.split(":", 1)[1]
+    evidence = verdict.evidence
+    if candidate.source.startswith("network:"):
+        host = str(candidate.detail.get("remote_host") or candidate.path)
+        evidence += (Evidence("enumerator", Channel.NETWORK, candidate.path,
+                              f"connected to model provider {host}", 0.75),)
+    return Observation(
+        kind=verdict.kind,
+        identity=verdict.catalog_id or candidate.path,
+        path=candidate.path,
+        install_root=_root_of(candidate.path),
+        owner=str(candidate.detail.get("user") or "system"),
+        version=verdict.version,
+        catalog_id=verdict.catalog_id,
+        package_id=_package_id(candidate),
+        content_hash=digest,
+        real_path=real_path,
+        inode=inode,
+        liveness=Liveness.RUNNING if candidate.kind == "process" else Liveness.INSTALLED,
+        evidence=evidence,
+        detail=detail,
+    )
+
+
+def _observation_from_declaration(candidate: Candidate, declaration: Declaration) -> Observation:
+    detail = {"name": declaration.name, "scope": declaration.scope,
+              "declared": True, "command": declaration.command}
+    detail.update(declaration.raw)
+    if declaration.kind is not Kind.MCP_SERVER:
+        detail["install_method"] = "agent_artifact"
+    return Observation(
+        kind=declaration.kind,
+        identity=f"{declaration.kind.value}:{declaration.name}",
+        path=declaration.path,
+        install_root=_root_of(declaration.path),
+        liveness=Liveness.DECLARED_ONLY,
+        evidence=(
+            Evidence("extractor", Channel.CONFIG, declaration.path,
+                     f"declared in {declaration.scope} scope", 0.85),
+        ),
+        detail=detail,
+    )
+
+
+def _mark_undeclared(assets: tuple[Asset, ...], declarations) -> tuple[Asset, ...]:
+    """Declared-versus-running, correlated rather than guessed.
+
+    A running server that no configuration declares is close to a definition
+    of unsanctioned -- and is also the finding most easily turned into
+    noise, which is why it is decided here against the declaration set and
+    never from a command line.
+    """
+    from dataclasses import replace
+
+    declared_names = {d.name for _, d in declarations}
+    out = []
+    for asset in assets:
+        if (
+            asset.kind is Kind.MCP_SERVER
+            and asset.liveness is Liveness.RUNNING
+            and asset.name not in declared_names
+        ):
+            out.append(replace(asset, flags=asset.flags + ("undeclared",)))
+        else:
+            out.append(asset)
+    return tuple(out)
+
+
+def _declarations_by_asset(assets: tuple[Asset, ...], declarations) -> dict[str, Declaration]:
+    by_name = {d.name: d for _, d in declarations}
+    return {a.asset_id: by_name[a.name] for a in assets if a.name in by_name}
+
+
+def _is_file(stat) -> bool:
+    #: S_IFREG without importing `stat` -- world/ owns the OS, not this file.
+    return (stat.mode & 0o170000) == 0o100000
+
+
+def _root_of(path: str | None) -> str | None:
+    if not path or "/" not in path:
+        return None
+    return path.rsplit("/", 1)[0]
+
+
+def _package_id(candidate: Candidate) -> str | None:
+    if not candidate.source.startswith("package:"):
+        return None
+    manager = candidate.source.split(":", 1)[1]
+    name = candidate.detail.get("name")
+    return f"{manager}:{name}" if name else None

--- a/Discovery/adr_discovery/tests_unit/conftest.py
+++ b/Discovery/adr_discovery/tests_unit/conftest.py
@@ -1,0 +1,113 @@
+"""Fixture worlds.
+
+A fixture directory and a live machine are interchangeable below M1, so
+every case here builds a world on disk and drives the real pipeline over
+it. Nothing is mocked; the gate reads these trees exactly as it reads `/`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from adr_discovery.catalog.load import loads as load_catalog
+from adr_discovery.coverage.ledger import Ledger
+from adr_discovery.world.budget import Budget
+from adr_discovery.world.gate import Gate
+from adr_discovery.world.platform.base import FixtureProviders
+
+PACKAGE = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+class World:
+    """A machine on disk, plus the non-filesystem surfaces beside it."""
+
+    def __init__(self, root: str) -> None:
+        self.root = root
+        self._restore: list[str] = []
+
+    def cleanup(self) -> None:
+        for path in self._restore:
+            try:
+                os.chmod(path, 0o755)
+            except OSError:
+                pass
+
+    def file(self, path: str, body: str = "") -> "World":
+        full = self.root + path
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w", encoding="utf-8") as fh:
+            fh.write(body)
+        return self
+
+    def json(self, path: str, document) -> "World":
+        return self.file(path, json.dumps(document))
+
+    def binary(self, path: str, body: str) -> "World":
+        """Exact bytes, plus the executable bit.
+
+        `exe` writes a shell wrapper of its own devising, which is fine for
+        version probes and useless for a case that asserts on a hash.
+        """
+        self.file(path, body)
+        os.chmod(self.root + path, 0o755)
+        return self
+
+    def exe(self, path: str, prints: str) -> "World":
+        self.file(path, f"#!/bin/sh\necho {prints!r}\n")
+        os.chmod(self.root + path, 0o755)
+        return self
+
+    def dir(self, path: str) -> "World":
+        os.makedirs(self.root + path, exist_ok=True)
+        return self
+
+    def unreadable(self, path: str) -> "World":
+        """Make a directory unreadable, and restore it at teardown.
+
+        Without the restore, pytest cannot clean its own tmp tree and every
+        later run inherits the mess.
+        """
+        os.chmod(self.root + path, 0o000)
+        self._restore.append(self.root + path)
+        return self
+
+    def symlink(self, path: str, target: str, outside: bool = False) -> "World":
+        """`target` is a path *inside* this world unless `outside` is set.
+
+        The distinction matters: a link out of the world is refused for
+        containment before the deny-list is ever consulted, so a case about
+        the deny-list has to stay inside.
+        """
+        full = self.root + path
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        os.symlink(target if outside else self.root + target, full)
+        return self
+
+    def surface(self, name: str, rows) -> "World":
+        """processes | sockets | packages | applications | dns | execjournal"""
+        return self.json(f"/{name}.json", rows)
+
+    def gate(self, **kwargs) -> Gate:
+        kwargs.setdefault("ledger", Ledger())
+        kwargs.setdefault("budget", Budget(max_entries=50_000))
+        kwargs.setdefault("providers", FixtureProviders())
+        kwargs.setdefault("env", {"PATH": "/usr/bin:/bin"})
+        return Gate(self.root, **kwargs)
+
+
+@pytest.fixture
+def world(tmp_path):
+    built = World(str(tmp_path))
+    try:
+        yield built
+    finally:
+        built.cleanup()
+
+
+@pytest.fixture(scope="session")
+def catalog():
+    with open(os.path.join(PACKAGE, "catalog", "catalog.json"), encoding="utf-8") as fh:
+        return load_catalog(fh.read())

--- a/Discovery/adr_discovery/tests_unit/test_ci_agents.py
+++ b/Discovery/adr_discovery/tests_unit/test_ci_agents.py
@@ -1,0 +1,83 @@
+"""CI agents -- an agent arranged to run with no person present.
+
+Invisible to every other source: nothing about it exists on the endpoint
+except a YAML file in a directory no binary scan reads.
+"""
+
+from __future__ import annotations
+
+from adr_discovery.contracts.records import Candidate, Kind
+from adr_discovery.extractor import extract
+from adr_discovery.pipeline import discover
+
+WORKFLOW = """name: review
+on:
+  pull_request:
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: secret-value-here
+        with:
+          mode: agent
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+      - uses: actions/cache@v4
+"""
+
+
+def read(world, path="/proj/.github/workflows/review.yml", body=WORKFLOW):
+    world.file(path, body)
+    return extract(world.gate(), Candidate(kind="marker_file", path=path, source="sweep"))
+
+
+def test_an_agent_step_becomes_a_declaration(world):
+    result = read(world)
+
+    (declaration,) = result.declarations
+    assert declaration.kind is Kind.CI_AGENT
+    assert declaration.raw["catalog_id"] == "claude-code"
+    assert declaration.raw["job"] == "review"
+    assert declaration.raw["unattended"] is True
+
+
+def test_build_steps_are_not_agents(world):
+    """`uses: actions/checkout@v4` is not an AI agent however many agents
+    run after it -- the precision half of this source."""
+    result = read(world)
+
+    assert len(result.declarations) == 1, "only the agent step counts"
+
+
+def test_env_names_survive_and_values_do_not(world):
+    (declaration,) = read(world).declarations
+
+    assert "ANTHROPIC_API_KEY" in declaration.env_names
+    assert "with.mode" in declaration.env_names
+    assert "secret-value-here" not in repr(declaration)
+
+
+def test_a_workflow_with_no_agent_yields_nothing(world):
+    result = read(world, body="""name: ci
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+""")
+
+    assert result.declarations == () and result.declared == 0
+
+
+def test_a_ci_agent_reaches_the_snapshot(world, catalog):
+    world.file("/Users/a/proj/.github/workflows/review.yml", WORKFLOW)
+
+    snapshot = discover(world.gate(), catalog)
+
+    agents = [a for a in snapshot.assets if a.kind is Kind.CI_AGENT]
+    assert len(agents) == 1
+    assert "claude-code-action" in agents[0].name

--- a/Discovery/adr_discovery/tests_unit/test_cli_security.py
+++ b/Discovery/adr_discovery/tests_unit/test_cli_security.py
@@ -1,0 +1,52 @@
+"""Security defaults at the process boundary."""
+
+import os
+
+import pytest
+from adr_discovery.world.gate import Gate
+
+from adr_discovery import cli
+from adr_discovery.cli import _load_json_mapping, _terminal, _write_private, build_parser
+
+
+def test_discovered_subprocess_api_does_not_exist():
+    assert not hasattr(Gate(), "run")
+    assert "allow-subprocess" not in build_parser().format_help()
+
+
+def test_snapshot_is_private_and_never_overwrites(tmp_path):
+    output = tmp_path / "output"
+    target = _write_private(str(output), "snapshot.json", "{}")
+
+    assert os.stat(target).st_mode & 0o777 == 0o600
+    with pytest.raises(FileExistsError):
+        _write_private(str(output), "snapshot.json", "replacement")
+
+
+def test_snapshot_target_symlink_is_not_followed(tmp_path):
+    output = tmp_path / "output"
+    output.mkdir()
+    victim = tmp_path / "victim"
+    victim.write_text("safe")
+    (output / "snapshot.json").symlink_to(victim)
+
+    with pytest.raises(FileExistsError):
+        _write_private(str(output), "snapshot.json", "owned")
+
+    assert victim.read_text() == "safe"
+
+
+def test_terminal_controls_and_bidi_are_escaped():
+    assert _terminal("good\x1b[31m\u202eevil") == "good\\x1b[31m\\u202eevil"
+
+
+def test_optional_json_must_be_a_bounded_object(tmp_path, monkeypatch):
+    document = tmp_path / "input.json"
+    document.write_text("[]")
+    with pytest.raises(ValueError, match="root must be an object"):
+        _load_json_mapping(str(document), "test")
+
+    monkeypatch.setattr(cli, "MAX_JSON_INPUT", 2)
+    document.write_text("{} ")
+    with pytest.raises(ValueError, match="exceeds"):
+        _load_json_mapping(str(document), "test")

--- a/Discovery/adr_discovery/tests_unit/test_cli_security.py
+++ b/Discovery/adr_discovery/tests_unit/test_cli_security.py
@@ -3,10 +3,10 @@
 import os
 
 import pytest
-from adr_discovery.world.gate import Gate
 
 from adr_discovery import cli
 from adr_discovery.cli import _load_json_mapping, _terminal, _write_private, build_parser
+from adr_discovery.world.gate import Gate
 
 
 def test_discovered_subprocess_api_does_not_exist():

--- a/Discovery/adr_discovery/tests_unit/test_content_identity.py
+++ b/Discovery/adr_discovery/tests_unit/test_content_identity.py
@@ -1,0 +1,88 @@
+"""Content identity -- M4 rung 2, and M5's strongest merge key.
+
+These two live together because they are the same read: the hash that
+identifies a self-compiled build is the hash that merges a copy of it
+found somewhere else.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from adr_discovery.catalog.load import CatalogError
+from adr_discovery.catalog.load import loads as load_catalog
+from adr_discovery.contracts.evidence import Rung
+from adr_discovery.contracts.records import Candidate, Priority
+from adr_discovery.identifier import content_hash, identify
+from adr_discovery.pipeline import discover
+
+BODY = "#!/bin/sh\necho 2.1.234\n"
+DIGEST = hashlib.sha256(BODY.encode()).hexdigest()
+
+
+def catalog_with_hash(digest=DIGEST):
+    return load_catalog(json.dumps({"version": "test", "entries": [{
+        "id": "claude-code", "name": "Claude Code", "vendor": "Anthropic", "kind": "cli_agent",
+        "fingerprints": {"binaries": ["claude"]},
+        "proofs": {"content_hashes": [digest]},
+    }]}))
+
+
+def test_the_loader_indexes_content_hashes():
+    """Without this index, rung 2 is dead code that silently never fires."""
+    catalog = catalog_with_hash()
+
+    assert catalog.match("content_hashes", DIGEST).id == "claude-code"
+
+
+def test_a_hash_claimed_by_two_entries_fails_the_load():
+    document = {"entries": [
+        {"id": "a", "name": "A", "vendor": "V", "kind": "cli_agent",
+         "proofs": {"content_hashes": [DIGEST]}},
+        {"id": "b", "name": "B", "vendor": "V", "kind": "cli_agent",
+         "proofs": {"content_hashes": [DIGEST]}},
+    ]}
+
+    with pytest.raises(CatalogError, match="ambiguous"):
+        load_catalog(json.dumps(document))
+
+
+def test_content_identifies_a_build_with_no_package_record(world):
+    """A self-compiled binary under a name nobody recognises."""
+    world.binary("/opt/built/mystery-tool", BODY)
+    gate = world.gate()
+
+    verdict = identify(gate, Candidate("binary", "/opt/built/mystery-tool", "sweep",
+                                       Priority.HOME), catalog_with_hash())
+
+    assert verdict.catalog_id == "claude-code"
+    assert verdict.rung is Rung.CONTENT
+    assert verdict.is_concluded
+
+
+def test_a_partial_read_never_produces_a_hash(world):
+    """A hash of truncated bytes is worse than no hash: it is a confident
+    wrong answer that would merge two unrelated things."""
+    from adr_discovery.world.budget import Budget
+
+    world.file("/big", "x" * 5000)
+    gate = world.gate(budget=Budget(max_read_bytes=1000))
+
+    assert content_hash(gate, "/big") is None
+
+
+def test_two_copies_of_one_binary_are_one_asset(world):
+    """Same bytes, two paths, no package record and no shared inode --
+    content is the only key that can merge them."""
+    world.binary("/opt/a/claude", BODY)
+    world.binary("/opt/b/claude", BODY)
+    gate = world.gate()
+
+    snapshot = discover(gate, catalog_with_hash())
+
+    agents = [a for a in snapshot.assets if a.catalog_id == "claude-code"]
+    assert len(agents) == 1, "a copy is not a second install"
+    assert "merged_2" in agents[0].flags

--- a/Discovery/adr_discovery/tests_unit/test_cross_cutting.py
+++ b/Discovery/adr_discovery/tests_unit/test_cross_cutting.py
@@ -1,0 +1,170 @@
+"""C1 catalog · C2 redaction · C3 coverage.
+
+The three concerns that are not stages. Their cases are shaped differently:
+C1 is almost entirely about rejection at load, C2 measures both directions
+of a filter, and C3 can only be tested by planting something real and
+making it unreachable.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from adr_discovery.catalog.load import CatalogError
+from adr_discovery.catalog.load import loads as load_catalog
+from adr_discovery.contracts.snapshot import OUT_OF_SCOPE
+from adr_discovery.pipeline import discover
+from adr_discovery.redact import rules as redact
+from adr_discovery.reporter import to_json
+
+
+def entry(**kwargs):
+    base = {"id": "a", "name": "A", "vendor": "V", "kind": "cli_agent"}
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------- C1 catalog
+
+
+def test_uc1_01_an_ambiguous_fingerprint_fails_the_load():
+    document = {"entries": [
+        entry(id="a", fingerprints={"binaries": ["codex"]}),
+        entry(id="b", fingerprints={"binaries": ["codex"]}),
+    ]}
+
+    with pytest.raises(CatalogError, match="ambiguous"):
+        load_catalog(json.dumps(document))
+
+
+def test_uc1_02_a_probe_without_a_shape_is_rejected():
+    document = {"entries": [entry(proofs={"version_probe": ["--version"]})]}
+
+    with pytest.raises(CatalogError, match="version_shape"):
+        load_catalog(json.dumps(document))
+
+
+def test_uc1_03_a_bad_shape_is_rejected_at_load_not_at_match():
+    document = {"entries": [entry(proofs={"version_probe": ["-v"], "version_shape": "[unclosed"})]}
+
+    with pytest.raises(CatalogError, match="regex"):
+        load_catalog(json.dumps(document))
+
+
+def test_uc1_04_the_shipped_catalog_obeys_its_own_rules(catalog):
+    assert len(catalog) > 0
+    assert catalog.version != "unknown"
+
+
+# -------------------------------------------------------------- C2 redaction
+
+
+def test_uc2_01_no_canary_survives_a_full_run(world, catalog):
+    world.file("/Users/alice/proj/.mcp.json", json.dumps({"mcpServers": {
+        "r": {"url": "https://user:PW-CANARY@h.example:8443/sse?tok=TOK-CANARY",
+              "env": {"ANTHROPIC_API_KEY": "sk-ant-KEY-CANARY"}},
+    }}))
+    gate = world.gate()
+
+    blob = to_json(discover(gate, catalog))
+
+    for canary in ("PW-CANARY", "TOK-CANARY", "sk-ant-KEY-CANARY"):
+        assert canary not in blob, f"{canary} escaped"
+
+
+def test_uc2_02_a_flag_name_survives_redaction():
+    """Dropping it is a permission bypass nobody detects, and no leak test
+    would notice."""
+    scrubbed = redact.scrub_argv(("claude", "-p", "SECRET", "--dangerously-skip-permissions"))
+
+    assert "--dangerously-skip-permissions" in scrubbed
+    assert "SECRET" not in scrubbed
+
+
+def test_uc2_04_explain_names_every_rule_it_enforces():
+    lines = redact.explain()
+
+    assert any(str(len(redact.CREDENTIAL_FLAGS)) in line for line in lines)
+    assert any(str(len(redact.PERSONAL_PATH_SEGMENTS)) in line for line in lines)
+
+
+def test_uc2_05_personal_path_denial_is_inherited_from_m1(world):
+    """A stage added tomorrow inherits this without containing a rule."""
+    world.file("/Users/alice/Documents/notes.json", "{}")
+    gate = world.gate()
+
+    assert not gate.read_text("/Users/alice/Documents/notes.json").ok
+    assert redact.is_personal("/Users/alice/Documents/notes.json")
+
+
+# --------------------------------------------------------------- C3 coverage
+
+
+def test_uc3_01_an_unreachable_asset_is_explained(world, catalog):
+    """Plant something real, make it unreachable, require an explanation."""
+    world.exe("/opt/hidden/claude", "2.1.234")
+    world.unreadable("/opt/hidden")
+    gate = world.gate()
+
+    snapshot = discover(gate, catalog)
+
+    assert not snapshot.coverage.is_complete
+    assert snapshot.coverage.denied or snapshot.coverage.unavailable
+
+
+def test_uc3_02_out_of_scope_is_named_on_a_machine_that_has_none(world, catalog):
+    snapshot = discover(world.gate(), catalog)
+
+    assert snapshot.coverage.out_of_scope == OUT_OF_SCOPE
+    assert "instruction_files" in snapshot.coverage.out_of_scope
+
+
+def test_uc3_03_every_boundary_kind_is_reachable(world):
+    """A boundary type no case can produce is a code path no run exercised."""
+    from adr_discovery.coverage.ledger import Ledger
+
+    ledger = Ledger()
+    ledger.boundary("/a", "depth")
+    ledger.boundary("/b", "entry_cap")
+    ledger.boundary("/c", "budget_exhausted")
+    ledger.deny("/d", "eacces")
+    ledger.unavailable("dpkg", "absent")
+    ledger.truncate("/e", 10, 100)
+
+    coverage = ledger.freeze()
+
+    assert {b.boundary for b in coverage.boundaries_hit} == {"depth", "entry_cap", "budget_exhausted"}
+    assert coverage.denied and coverage.unavailable and coverage.truncated
+    assert not coverage.is_complete
+
+
+def test_uc2_03_a_stage_that_never_calls_a_redactor_still_cannot_leak():
+    """Redaction is carried by the type, not applied by whoever constructs it.
+
+    This is the case that decides whether C2 is a rule or a habit: a final
+    pass is something a stage added tomorrow can be placed behind, and a
+    constructor is not. The declaration below is built the way a brand-new
+    extractor would build one -- raw values, no redactor in sight.
+    """
+    from adr_discovery.contracts.records import Declaration, Kind
+
+    naive = Declaration(
+        kind=Kind.MCP_SERVER,
+        name="new-surface",
+        path="/cfg",
+        command="server",
+        args=("--token", "TOK-CANARY", "--api-key=KEY-CANARY", "--model", "opus"),
+        url="https://user:PW-CANARY@h.example:8443/sse?tok=Q-CANARY",
+        raw={"env": {"ANTHROPIC_API_KEY": "sk-ant-KEY-CANARY"}},
+    )
+
+    blob = repr(naive)
+    for canary in ("TOK-CANARY", "KEY-CANARY", "PW-CANARY", "Q-CANARY", "sk-ant-KEY-CANARY"):
+        assert canary not in blob, f"{canary} survived construction"
+
+    # The other direction: names and shapes are kept, or the record is useless.
+    assert "--token" in naive.args and "--model" in naive.args and "opus" in naive.args
+    assert naive.url == "https://h.example:8443/sse"
+    assert naive.raw["env"] == ("ANTHROPIC_API_KEY",)

--- a/Discovery/adr_discovery/tests_unit/test_import_rules.py
+++ b/Discovery/adr_discovery/tests_unit/test_import_rules.py
@@ -1,0 +1,153 @@
+"""The rules that make the package modular, checked against the code.
+
+Every other guarantee in this design is a claim about intent. This one is a
+claim about the code: it walks the import graph, runs in well under a
+second, and fails on the pull request that would have reintroduced the
+problem the rewrite exists to remove.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PACKAGE = os.path.abspath(os.path.join(HERE, ".."))
+
+STAGES = ("world", "enumerator", "extractor", "identifier", "resolver", "judge", "reporter")
+CROSS_CUTTING = ("catalog", "redact", "coverage")
+BASE = ("contracts",)
+
+#: Modules that reach the operating system directly.
+HOST_MODULES = {"os", "os.path", "pathlib", "subprocess", "socket", "shutil", "glob"}
+
+#: `world/` is the door. `cli.py` is the process boundary -- it owns argv,
+#: stdout, the exit code and the output file, none of which are the machine
+#: under inventory. Nothing else may touch the host, and the test asserts
+#: this list stays exactly two entries long.
+HOST_ALLOWED = ("world", "cli.py")
+
+
+def _modules():
+    for dirpath, dirnames, filenames in os.walk(PACKAGE):
+        dirnames[:] = [d for d in dirnames if d not in {"__pycache__", "tests_unit"}]
+        for name in filenames:
+            if name.endswith(".py"):
+                full = os.path.join(dirpath, name)
+                yield os.path.relpath(full, PACKAGE), full
+
+
+def _imports(path: str):
+    """(module, is_relative, level) for every import in the file."""
+    with open(path, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), path)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name, False, 0
+        elif isinstance(node, ast.ImportFrom):
+            yield (node.module or ""), node.level > 0, node.level
+
+
+def _top_package(rel: str) -> str:
+    return rel.split(os.sep)[0]
+
+
+def _resolved_target(rel: str, module: str, level: int) -> str:
+    """Which top-level package a relative import points at."""
+    parts = rel.split(os.sep)[:-1]
+    base = parts[: len(parts) - (level - 1)] if level > 1 else parts
+    return (base + module.split("."))[0] if (base or module) else ""
+
+
+# --------------------------------------------------------------------------
+
+
+def test_only_world_touches_the_host():
+    offenders = []
+    for rel, full in _modules():
+        top = _top_package(rel)
+        if top in HOST_ALLOWED or rel in HOST_ALLOWED:
+            continue
+        for module, is_relative, _ in _imports(full):
+            if is_relative:
+                continue
+            if module in HOST_MODULES or module.split(".")[0] in HOST_MODULES:
+                offenders.append(f"{rel} imports {module}")
+    assert not offenders, "only world/ may touch the host:\n  " + "\n  ".join(offenders)
+
+
+def test_host_exemption_list_has_not_grown():
+    # A rule whose exemption list can grow silently is not a rule.
+    assert HOST_ALLOWED == ("world", "cli.py")
+
+
+def test_no_stage_imports_a_sibling_stage():
+    offenders = []
+    for rel, full in _modules():
+        top = _top_package(rel)
+        if top not in STAGES:
+            continue
+        for module, is_relative, level in _imports(full):
+            target = _resolved_target(rel, module, level) if is_relative else module.split(".")[0]
+            if target in STAGES and target != top:
+                offenders.append(f"{rel} imports stage {target}")
+    assert not offenders, "a stage imported a sibling:\n  " + "\n  ".join(offenders)
+
+
+def test_only_the_pipeline_imports_more_than_one_stage():
+    offenders = []
+    for rel, full in _modules():
+        if rel in ("pipeline.py", "cli.py") or _top_package(rel) in STAGES:
+            continue
+        touched = set()
+        for module, is_relative, level in _imports(full):
+            target = _resolved_target(rel, module, level) if is_relative else module.split(".")[0]
+            if target in STAGES:
+                touched.add(target)
+        if len(touched) > 1:
+            offenders.append(f"{rel} imports {sorted(touched)}")
+    assert not offenders, "order must live in pipeline.py alone:\n  " + "\n  ".join(offenders)
+
+
+def test_catalog_imports_nothing_from_the_package():
+    package_names = set(STAGES) | set(CROSS_CUTTING) | set(BASE) | {"pipeline", "cli"}
+    offenders = []
+    for rel, full in _modules():
+        if _top_package(rel) != "catalog":
+            continue
+        for module, is_relative, level in _imports(full):
+            if is_relative and _resolved_target(rel, module, level) != "catalog":
+                offenders.append(f"{rel} imports {module or '..'}")
+            elif not is_relative and module.split(".")[0] in package_names:
+                offenders.append(f"{rel} imports {module}")
+    assert not offenders, (
+        "the catalog ships on its own cadence and may not depend on the collector:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_no_stage_holds_mutable_module_level_state():
+    """`PROJECT_ROOTS` in five files is the defect this rewrite exists for.
+
+    Module-level containers are allowed only if immutable, so a stage cannot
+    accumulate state between runs or disagree with a sibling about a value.
+    """
+    offenders = []
+    for rel, full in _modules():
+        if _top_package(rel) not in STAGES:
+            continue
+        with open(full, encoding="utf-8") as fh:
+            tree = ast.parse(fh.read(), full)
+        for node in tree.body:
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            value = node.value
+            if isinstance(value, (ast.List, ast.Dict, ast.Set)):
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                names = [
+                    t.id for t in targets
+                    if isinstance(t, ast.Name) and t.id != "__all__"  # module protocol, not state
+                ]
+                offenders.extend(f"{rel}: {n} is a mutable module-level container" for n in names)
+    assert not offenders, "\n  ".join(offenders)

--- a/Discovery/adr_discovery/tests_unit/test_pipeline.py
+++ b/Discovery/adr_discovery/tests_unit/test_pipeline.py
@@ -1,0 +1,88 @@
+"""The composition root, end to end over a fixture world.
+
+These assert on the seams the per-module cases cannot see: that a
+declaration and the process running it become one asset, that an
+instruction file never becomes one, and that the snapshot's coverage
+accounts for what the scan could not reach.
+"""
+
+from __future__ import annotations
+
+import json
+
+from adr_discovery.contracts.records import Kind, Liveness
+from adr_discovery.judge import Policy
+from adr_discovery.pipeline import discover
+from adr_discovery.reporter import stats, to_json
+
+
+def endpoint(world):
+    world.dir("/Users/alice")
+    world.exe("/opt/homebrew/bin/claude", "2.1.234")
+    world.file("/Users/alice/.claude/settings.json", "{}")
+    world.json("/Users/alice/work/proj/.mcp.json", {"mcpServers": {
+        "github": {"command": "npx", "args": ["-y", "server-github"]},
+        "files": {"command": "npx", "args": ["-y", "@mcp/server-filesystem@1.4.2"]},
+        "legacy": {"url": "http://legacy.example.com/sse"},
+        "broken": "not a mapping",
+    }})
+    world.file("/Users/alice/work/proj/CLAUDE.md", "# steering prose")
+    world.surface("packages", [{"manager": "npm", "name": "@anthropic-ai/claude-code",
+                                "version": "2.1.234", "path": "/opt/homebrew/bin/claude"}])
+    world.surface("processes", [{"pid": 900, "exe": "/opt/homebrew/bin/claude",
+                                 "argv": ["claude", "-p"], "ppid": 1, "user": "alice"}])
+    return world
+
+
+def test_a_binary_and_the_process_running_it_are_one_asset(world, catalog):
+    snapshot = discover(endpoint(world).gate(), catalog)
+
+    agents = [a for a in snapshot.assets if a.kind is Kind.CLI_AGENT]
+
+    assert len(agents) == 1, "the false split M5 exists to stop"
+    assert agents[0].liveness is Liveness.RUNNING
+    assert agents[0].version == "2.1.234"
+
+
+def test_an_instruction_file_becomes_inventory_without_collecting_its_body(world, catalog):
+    snapshot = discover(endpoint(world).gate(), catalog)
+
+    instructions = [a for a in snapshot.assets if a.kind is Kind.INSTRUCTIONS]
+    assert [a.install_path for a in instructions] == ["/Users/alice/work/proj/CLAUDE.md"]
+    assert "steering prose" not in to_json(snapshot)
+
+
+def test_a_malformed_record_does_not_remove_its_siblings(world, catalog):
+    snapshot = discover(endpoint(world).gate(), catalog)
+
+    servers = {a.name for a in snapshot.assets if a.kind is Kind.MCP_SERVER}
+
+    assert servers == {"github", "files", "legacy"}
+
+
+def test_findings_are_narrow(world, catalog):
+    snapshot = discover(endpoint(world).gate(), catalog, Policy())
+
+    rules = sorted(f.rule for f in snapshot.findings)
+
+    assert rules == ["plaintext_transport", "unpinned_mcp_server"]
+    assert all(f.asset_id for f in snapshot.findings)
+
+
+def test_the_snapshot_carries_its_coverage(world, catalog):
+    gate = endpoint(world).gate()
+
+    snapshot = discover(gate, catalog)
+
+    assert not snapshot.coverage.is_complete, "surfaces this fixture cannot supply must be named"
+    assert "exec_journal" in [u.provider for u in snapshot.coverage.unavailable]
+    assert snapshot.coverage.out_of_scope
+
+
+def test_an_empty_world_still_produces_a_snapshot(world, catalog):
+    snapshot = discover(world.gate(), catalog, hostname="clean-host")
+
+    assert snapshot.assets == ()
+    assert snapshot.hostname == "clean-host"
+    assert json.loads(to_json(snapshot))["coverage"]["out_of_scope"]
+    assert stats(snapshot)["asset_count"] == 0

--- a/Discovery/adr_discovery/tests_unit/test_roundtrip_and_telemetry.py
+++ b/Discovery/adr_discovery/tests_unit/test_roundtrip_and_telemetry.py
@@ -1,0 +1,80 @@
+"""Reading a snapshot back, and the one signal an endpoint cannot produce.
+
+The delta is the product, so a snapshot that can only be written is a
+snapshot that can only be filed away. And `last_used` is the join that
+turns a configured-but-never-invoked server from a threat into a cleanup
+candidate -- it comes from session telemetry, not from the filesystem.
+"""
+
+from __future__ import annotations
+
+import json
+
+from adr_discovery.contracts.records import Kind, Liveness
+from adr_discovery.pipeline import discover
+from adr_discovery.reporter import diff, from_dict, to_json
+
+
+def endpoint(world):
+    world.dir("/Users/alice")
+    world.binary("/opt/homebrew/bin/claude", "#!/bin/sh\necho 2.1.234\n")
+    world.surface("packages", [{"manager": "npm", "name": "@anthropic-ai/claude-code",
+                                "version": "2.1.234", "path": "/opt/homebrew/bin/claude"}])
+    world.json("/Users/alice/proj/.mcp.json", {"mcpServers": {
+        "github": {"command": "npx", "args": ["-y", "server-github"]}}})
+    return world
+
+
+def test_a_snapshot_survives_the_round_trip(world, catalog):
+    original = discover(endpoint(world).gate(), catalog, hostname="host-a")
+
+    restored = from_dict(json.loads(to_json(original)))
+
+    assert restored.hostname == original.hostname
+    assert len(restored.assets) == len(original.assets)
+    assert {a.asset_id for a in restored.assets} == {a.asset_id for a in original.assets}
+    assert {a.kind for a in restored.assets} == {a.kind for a in original.assets}
+    assert restored.coverage.out_of_scope == original.coverage.out_of_scope
+
+
+def test_a_round_tripped_snapshot_diffs_cleanly_against_itself(world, catalog):
+    """Two scans of an unchanged machine must produce no delta, which is a
+    statement about `asset_id` holding still through serialization."""
+    original = discover(endpoint(world).gate(), catalog, hostname="host-a")
+    restored = from_dict(json.loads(to_json(original)))
+
+    delta = diff(restored, original)
+
+    assert delta.is_empty, [c.kind for c in delta.changes]
+
+
+def test_a_real_change_survives_serialization(world, catalog):
+    before = discover(endpoint(world).gate(), catalog, hostname="host-a")
+    world.binary("/opt/homebrew/bin/claude", "#!/bin/sh\necho 2.2.0\n")
+    world.surface("packages", [{"manager": "npm", "name": "@anthropic-ai/claude-code",
+                                "version": "2.2.0", "path": "/opt/homebrew/bin/claude"}])
+    after = discover(world.gate(), catalog, hostname="host-a")
+
+    delta = diff(from_dict(json.loads(to_json(before))), after)
+
+    assert [c.kind for c in delta.of("version_changed")] == ["version_changed"]
+    assert delta.of("appeared") == () and delta.of("disappeared") == ()
+
+
+def test_telemetry_supplies_last_used(world, catalog):
+    snapshot = discover(endpoint(world).gate(), catalog,
+                        telemetry={"claude-code": "2026-08-21T09:12:00+00:00"})
+
+    (agent,) = [a for a in snapshot.assets if a.kind is Kind.CLI_AGENT]
+    assert agent.last_used == "2026-08-21T09:12:00+00:00"
+
+
+def test_configured_but_never_invoked_stays_distinct(world, catalog):
+    """A declared server with no telemetry is a cleanup candidate, not a
+    threat -- and the two must not look the same in a snapshot."""
+    snapshot = discover(endpoint(world).gate(), catalog,
+                        telemetry={"claude-code": "2026-08-21T09:12:00+00:00"})
+
+    (server,) = [a for a in snapshot.assets if a.kind is Kind.MCP_SERVER]
+    assert server.liveness is Liveness.DECLARED_ONLY
+    assert server.last_used is None

--- a/Discovery/pyproject.toml
+++ b/Discovery/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "adr-discovery"
+version = "0.2.0"
+description = "Inventory the AI binaries, agents, MCP servers and skills present on an employee endpoint"
+readme = "adr_discovery/README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "ruff>=0.6"]
+
+[project.scripts]
+adr-discovery = "adr_discovery.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["adr_discovery"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests", "adr_discovery/tests_unit"]
+pythonpath = ["."]
+
+[tool.ruff]
+line-length = 110
+target-version = "py311"
+
+[tool.ruff.lint]
+# Correctness and import hygiene. Style beyond this is not worth a build
+# gate; the rule that actually guards this package is the import test in
+# adr_discovery/tests_unit/test_import_rules.py.
+select = ["E", "F", "I", "B", "SIM"]
+ignore = ["E501", "SIM105", "B008"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["B011"]
+"adr_discovery/tests_unit/**" = ["B011"]

--- a/Discovery/uv.lock
+++ b/Discovery/uv.lock
@@ -1,0 +1,107 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "adr-discovery"
+version = "0.2.0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/8f/d8074b1f25e003164087a8bfe79a0f1a3945135764dbb6aaab04103dcaf9/ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc", size = 4899731, upload-time = "2026-08-20T17:43:59.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/80/779895ef584e089d22f2c6df0d0e99a65ec2df0805f1fffd439415b8c1f0/ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7", size = 10006909, upload-time = "2026-08-20T17:43:16.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e6/f553199b5e8927a05cb5c422d921fd0656b29ab976e91c44802107c6b0da/ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604", size = 10240201, upload-time = "2026-08-20T17:43:19.337Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255", size = 9835122, upload-time = "2026-08-20T17:43:21.708Z" },
+    { url = "https://files.pythonhosted.org/packages/24/12/c6e22d686372c15bcb7af99831f1a1be96df696491babf4f24e4f942c527/ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade", size = 9977162, upload-time = "2026-08-20T17:43:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/72b10ec912f5ab5854992eaf7aa7cd36729b6937d9dc4e0fb41b3bf428ec/ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff", size = 9829789, upload-time = "2026-08-20T17:43:26.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/0f30e32e7f6ee26edc39075502db9d368d788a44a79b55f763eb4ab03796/ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80", size = 10527949, upload-time = "2026-08-20T17:43:29.384Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3d/86e8ad3542169e56cac3859a343afdb9df2ad54d35a59ce1e67baee83421/ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07", size = 11333695, upload-time = "2026-08-20T17:43:31.872Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/16/481c29b380c20a0054a8261066665e1b3488e23636c49d0a43e75975b9bb/ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7", size = 10727741, upload-time = "2026-08-20T17:43:34.596Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3", size = 10286522, upload-time = "2026-08-20T17:43:37.288Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8b/b345b4fb110f2fbe2bd31eabd271e5e8b3b7e4ee6c0e02f2dc6be78db000/ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454", size = 10584182, upload-time = "2026-08-20T17:43:39.984Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e5/827b34041c35f58774a9681a4213994c164fc987800f4dddabcf451da0bf/ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b", size = 10134195, upload-time = "2026-08-20T17:43:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/d0bffcdd6729b87afc82ba0ef377173356a7dc8e972f5179968cf2fdf98c/ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d", size = 9825821, upload-time = "2026-08-20T17:43:44.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/32/0db2a863b796ca62d83e92a07a3ccf00921b14db02059347576a2fda3d4b/ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0", size = 10267658, upload-time = "2026-08-20T17:43:46.989Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a0/fbdeb59e48c6261f523e56c8f12e9c08fbe693786595cc7e3959207a9232/ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d", size = 10697071, upload-time = "2026-08-20T17:43:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+]


### PR DESCRIPTION
Composes the discovery package into a usable product surface:

- explicit M2-through-M7 pipeline composition
- command-line entry point and exit behavior
- Python package metadata and lockfile
- implementation-aligned package documentation
- import-boundary, privacy, identity, telemetry, pipeline, and integration tests

This is PR 5 of 5 functionality-based PRs. It targets main directly and is not stacked on another feature branch. It remains draft until the functional stages arrive through main.

Validation of the combined five-PR result: 218 tests passed; Ruff passed.

Replaces the integration and unit-test work from closed PRs #103-#104. Closed PR #105 is intentionally excluded because it contained untested, machine-specific intermediate run output.