### PR TITLE
test(sensor): isolate redirected APPDATA test

### DIFF
--- a/Sensor/tests/test_parsers.py
+++ b/Sensor/tests/test_parsers.py
@@ -1333,25 +1333,38 @@ class TestWindowsAppDataResolution:
 
     def test_redirected_appdata_end_to_end(self, tmp_path, monkeypatch):
         """A Cursor DB under a redirected %APPDATA% (outside the profile) is found."""
+        import importlib
+
+        from adr_sensor.parsers import cursor_parser as cursor_parser_module
+
         redirected = tmp_path / "fileserver/profiles$/alice/AppData/Roaming"
         db = redirected / "Cursor/User/globalStorage/state.vscdb"
         db.parent.mkdir(parents=True)
         db.touch()
 
-        monkeypatch.setenv("APPDATA", str(redirected))
+        try:
+            with monkeypatch.context() as isolated:
+                isolated.setenv("APPDATA", str(redirected))
+                # DB_PATHS is built at import time, so reload under the redirected env.
+                importlib.reload(cursor_parser_module)
 
-        windows_db = windows_appdata() / "Cursor/User/globalStorage/state.vscdb"
-        assert windows_db == db
+                reloaded_parser = cursor_parser_module.CursorParser
+                windows_candidate = reloaded_parser.DB_PATHS[-1]
+                assert windows_candidate == db
 
-        # Isolate this Windows-path test from real Cursor installations on the host.
-        monkeypatch.setattr(
-            CursorParser,
-            "DB_PATHS",
-            [
-                tmp_path / "missing-macos/state.vscdb",
-                tmp_path / "missing-linux/state.vscdb",
-                windows_db,
-            ],
-        )
+                # Preserve the parser's actual Windows candidate while preventing real
+                # macOS or Linux Cursor installations from winning the existence check.
+                isolated.setattr(
+                    reloaded_parser,
+                    "DB_PATHS",
+                    [
+                        tmp_path / "missing-macos/state.vscdb",
+                        tmp_path / "missing-linux/state.vscdb",
+                        windows_candidate,
+                    ],
+                )
 
-        assert CursorParser().db_path == db
+                assert reloaded_parser().db_path == db
+        finally:
+            # Restore module-level paths using the process's original environment.
+            importlib.reload(cursor_parser_module)

--- a/Sensor/tests/test_parsers.py
+++ b/Sensor/tests/test_parsers.py
@@ -1331,27 +1331,27 @@ class TestWindowsAppDataResolution:
         monkeypatch.delenv("LOCALAPPDATA", raising=False)
         assert windows_local_appdata() == Path.home() / "AppData/Local"
 
-    def test_redirected_appdata_end_to_end(self, tmp_path):
+    def test_redirected_appdata_end_to_end(self, tmp_path, monkeypatch):
         """A Cursor DB under a redirected %APPDATA% (outside the profile) is found."""
-        import importlib
-        import os as os_mod
-
-        from adr_sensor.parsers import cursor_parser as cursor_parser_module
-
         redirected = tmp_path / "fileserver/profiles$/alice/AppData/Roaming"
         db = redirected / "Cursor/User/globalStorage/state.vscdb"
         db.parent.mkdir(parents=True)
         db.touch()
 
-        original = os_mod.environ.get("APPDATA")
-        os_mod.environ["APPDATA"] = str(redirected)
-        try:
-            # DB_PATHS is built at import time, so reload under the redirected env.
-            importlib.reload(cursor_parser_module)
-            assert cursor_parser_module.CursorParser().db_path == db
-        finally:
-            if original is None:
-                os_mod.environ.pop("APPDATA", None)
-            else:
-                os_mod.environ["APPDATA"] = original
-            importlib.reload(cursor_parser_module)
+        monkeypatch.setenv("APPDATA", str(redirected))
+
+        windows_db = windows_appdata() / "Cursor/User/globalStorage/state.vscdb"
+        assert windows_db == db
+
+        # Isolate this Windows-path test from real Cursor installations on the host.
+        monkeypatch.setattr(
+            CursorParser,
+            "DB_PATHS",
+            [
+                tmp_path / "missing-macos/state.vscdb",
+                tmp_path / "missing-linux/state.vscdb",
+                windows_db,
+            ],
+        )
+
+        assert CursorParser().db_path == db


### PR DESCRIPTION
<!--

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/uber/ADR/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/uber/ADR/blob/main/CODE_OF_CONDUCT.md
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.

     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Link any related issue (e.g., "Closes #123"), or "N/A" if there is none -->
**Related issue**: 

N/A

<!-- Describe what has changed in this PR -->
**What changed?**

Updated the redirected `%APPDATA%` Cursor parser test to use pytest's `monkeypatch` fixture and deterministic database candidates.

<!-- Tell your future self why have you made these changes -->
**Why?**

The test previously searched the normal macOS Cursor database before the temporary Windows database. On macOS systems with Cursor installed, the real database was selected and the test failed.

The revised test is isolated from applications and log files installed on the host machine.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in a staging env? -->
**How did you test it?**

- `uv run pytest -q`
Result: `123 passed`
- `uv run ruff check adr_sensor tests`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Low. This changes test setup only and does not modify production parser behavior.

