### PR TITLE
fix(detection): follow local imports in MCP source retrieval

### DIFF
--- a/Detection/context_providers/source_code_analyzer_server.py
+++ b/Detection/context_providers/source_code_analyzer_server.py
@@ -5,11 +5,19 @@ ADR Source Code Context Provider
 Provides MCP server source code for reasoning-based threat analysis.
 No pre-analysis or cheating metadata - just clean source code and basic info.
 """
-import yaml
+import ast
 import logging
+import os
+from importlib.machinery import (
+    BYTECODE_SUFFIXES,
+    EXTENSION_SUFFIXES,
+    BuiltinImporter,
+    FrozenImporter,
+)
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Any, Dict, List, Optional, Tuple
 
+import yaml
 from mcp.server.fastmcp import FastMCP
 
 # Configure logging
@@ -39,6 +47,235 @@ def load_source_registry() -> Dict[str, Any]:
 
 source_registry = load_source_registry()
 
+
+MAX_LOCAL_SOURCE_FILES = 24
+MAX_LOCAL_SOURCE_CHARS = 240_000
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return whether a resolved path remains within the trusted server root."""
+
+    try:
+        path.resolve(strict=True).relative_to(root.resolve(strict=True))
+        return True
+    except (FileNotFoundError, OSError, RuntimeError, ValueError):
+        return False
+
+
+def _resolved_source_file(path: Path, root: Path) -> Optional[Path]:
+    """Return a regular in-root source file without following symlinked input."""
+
+    if not _is_within(path, root):
+        return None
+    try:
+        resolved = path.resolve(strict=True)
+    except (FileNotFoundError, OSError, RuntimeError):
+        return None
+    if resolved != Path(os.path.abspath(os.fspath(path))):
+        return None
+    return resolved if resolved.is_file() else None
+
+
+def _has_file_with_suffixes(path: Path, suffixes: List[str]) -> bool:
+    """Return whether a competing loader file exists for a module path."""
+
+    return any(path.with_name(path.name + suffix).is_file() for suffix in suffixes)
+
+
+def _runtime_import_precedes_local_source(module_name: str) -> bool:
+    """Return whether Python resolves a built-in or frozen module first."""
+
+    top_level = module_name.partition(".")[0]
+    if not top_level:
+        return False
+    return (
+        BuiltinImporter.find_spec(top_level) is not None
+        or FrozenImporter.find_spec(top_level) is not None
+    )
+
+
+def _resolve_module_parts(
+    base: Path,
+    parts: List[str],
+    root: Path,
+) -> Tuple[List[Path], Optional[Path]]:
+    """Resolve local source using Python's package-before-module precedence.
+
+    The returned package directory is used only to resolve ``from package
+    import submodule``. Native-extension and bytecode-only modules are not
+    represented as Python source and block same-name ``.py`` candidates when
+    Python would select them first.
+    """
+
+    files: List[Path] = []
+    if not parts:
+        initializer = _resolved_source_file(base / "__init__.py", root)
+        if initializer is not None:
+            files.append(initializer)
+        return files, base if _is_within(base, root) and base.is_dir() else None
+
+    current = base
+    for index, part in enumerate(parts):
+        final = index == len(parts) - 1
+        package_dir = current / part
+        module_stem = current / part
+
+        # FileFinder checks a package directory before same-named module files.
+        if package_dir.is_dir() and _is_within(package_dir, root):
+            initializer_stem = package_dir / "__init__"
+            has_extension_initializer = _has_file_with_suffixes(
+                initializer_stem, EXTENSION_SUFFIXES
+            )
+            has_source_initializer = (package_dir / "__init__.py").is_file()
+            has_bytecode_initializer = _has_file_with_suffixes(
+                initializer_stem, BYTECODE_SUFFIXES
+            )
+            if has_extension_initializer:
+                initializer = None
+            else:
+                initializer = _resolved_source_file(
+                    package_dir / "__init__.py", root
+                )
+            if (
+                has_extension_initializer
+                or has_source_initializer
+                or has_bytecode_initializer
+            ):
+                if has_source_initializer and initializer is None:
+                    return files, None
+                if initializer is not None:
+                    files.append(initializer)
+                if final:
+                    return files, package_dir
+                current = package_dir
+                continue
+
+        # Native extensions precede source modules. Source precedes bytecode.
+        if _has_file_with_suffixes(module_stem, EXTENSION_SUFFIXES):
+            return files, None
+        module = _resolved_source_file(module_stem.with_suffix(".py"), root)
+        if module is not None:
+            files.append(module)
+            return files, None
+        if _has_file_with_suffixes(module_stem, BYTECODE_SUFFIXES):
+            return files, None
+
+        # A directory without an initializer becomes a namespace package only
+        # if no same-name module loader matched above.
+        if package_dir.is_dir() and _is_within(package_dir, root):
+            if final:
+                return files, package_dir
+            current = package_dir
+            continue
+        return files, None
+
+    return files, None
+
+
+def _local_import_candidates(current: Path, node: ast.AST, root: Path) -> List[Path]:
+    """Resolve Python imports that refer to files inside one registered server."""
+
+    candidates: List[Path] = []
+    candidate_set = set()
+
+    def add(paths: List[Path]) -> None:
+        for path in paths:
+            if path not in candidate_set:
+                candidates.append(path)
+                candidate_set.add(path)
+
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            if _runtime_import_precedes_local_source(alias.name):
+                continue
+            files, _ = _resolve_module_parts(
+                root,
+                [part for part in alias.name.split(".") if part],
+                root,
+            )
+            add(files)
+        return candidates
+
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        level = int(node.level or 0)
+        if level:
+            base = current.parent
+            for _ in range(level - 1):
+                base = base.parent
+        else:
+            base = root
+
+        if not _is_within(base, root):
+            return candidates
+        if not level and _runtime_import_precedes_local_source(module):
+            return candidates
+
+        files, package_dir = _resolve_module_parts(
+            base,
+            [part for part in module.split(".") if part],
+            root,
+        )
+        add(files)
+        if package_dir is not None:
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                alias_files, _ = _resolve_module_parts(
+                    package_dir,
+                    [part for part in alias.name.split(".") if part],
+                    root,
+                )
+                add(alias_files)
+    return candidates
+
+
+def collect_local_source_files(entrypoint: Path) -> List[Dict[str, Any]]:
+    """Collect a bounded, dependency-aware source bundle for one MCP server.
+
+    Registry paths are trusted, but import resolution is constrained to the
+    entrypoint's server directory. Returned paths are relative so dataset
+    directory names do not become classifier hints.
+    """
+
+    root = entrypoint.parent.resolve()
+    entrypoint = _resolved_source_file(entrypoint, root)
+    if entrypoint is None:
+        return []
+    pending = [entrypoint]
+    seen = set()
+    files: List[Dict[str, str]] = []
+    total_chars = 0
+    while pending and len(files) < MAX_LOCAL_SOURCE_FILES:
+        path = pending.pop(0)
+        path = _resolved_source_file(path, root)
+        if path is None or path in seen:
+            continue
+        seen.add(path)
+        source = path.read_text(encoding="utf-8")
+        remaining = MAX_LOCAL_SOURCE_CHARS - total_chars
+        if remaining <= 0:
+            break
+        truncated = len(source) > remaining
+        included = source[:remaining]
+        files.append({
+            "path": str(path.relative_to(root)),
+            "source_code": included,
+            "truncated": truncated,
+        })
+        total_chars += len(included)
+        if truncated:
+            break
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except (SyntaxError, ValueError):
+            continue
+        for node in ast.walk(tree):
+            for dependency in _local_import_candidates(path, node, root):
+                if dependency not in seen and dependency not in pending:
+                    pending.append(dependency)
+    return files
+
 @mcp.tool()
 def get_source_code(server_names: List[str]) -> Dict[str, Any]:
     """Get the source code of MCP servers for analysis"""
@@ -61,12 +298,15 @@ def get_source_code(server_names: List[str]) -> Dict[str, Any]:
 
         # Read source code
         server_path = server_info.get("path", "")
-        full_path = Path(__file__).parent / server_path
+        provider_root = Path(__file__).parent.resolve()
+        full_path = provider_root / server_path
 
         try:
-            if full_path.exists():
-                with open(full_path, 'r') as f:
+            resolved_path = _resolved_source_file(full_path, provider_root)
+            if resolved_path is not None:
+                with open(resolved_path, 'r') as f:
                     source_code = f.read()
+                source_files = collect_local_source_files(resolved_path)
 
                 # Provide clean metadata without cheating indicators
                 source_codes.append({
@@ -77,7 +317,14 @@ def get_source_code(server_names: List[str]) -> Dict[str, Any]:
                         "description": server_info.get("description"),
                         "capabilities": server_info.get("capabilities", [])
                     },
-                    "source_code": source_code
+                    # Keep the original field for compatibility and add the
+                    # dependency-aware bundle for complete source reasoning.
+                    "source_code": source_code,
+                    "entrypoint": resolved_path.name,
+                    "source_files": source_files,
+                    "source_bundle_complete": not any(
+                        item["truncated"] for item in source_files
+                    ),
                 })
             else:
                 source_codes.append({

--- a/Detection/context_providers/source_code_analyzer_server.py
+++ b/Detection/context_providers/source_code_analyzer_server.py
@@ -6,8 +6,10 @@ Provides MCP server source code for reasoning-based threat analysis.
 No pre-analysis or cheating metadata - just clean source code and basic info.
 """
 import ast
+import io
 import logging
 import os
+import tokenize
 from importlib.machinery import (
     BYTECODE_SUFFIXES,
     EXTENSION_SUFFIXES,
@@ -49,7 +51,7 @@ source_registry = load_source_registry()
 
 
 MAX_LOCAL_SOURCE_FILES = 24
-MAX_LOCAL_SOURCE_CHARS = 240_000
+MAX_LOCAL_SOURCE_BYTES = 240_000
 
 
 def _is_within(path: Path, root: Path) -> bool:
@@ -230,7 +232,43 @@ def _local_import_candidates(current: Path, node: ast.AST, root: Path) -> List[P
     return candidates
 
 
-def collect_local_source_files(entrypoint: Path) -> List[Dict[str, Any]]:
+def _read_bounded_python_source(path: Path, max_bytes: int) -> Tuple[str, bool]:
+    """Read at most ``max_bytes`` of Python source, honoring its encoding.
+
+    The returned text is also bounded by its UTF-8 encoded size because that is
+    the representation sent to the model. One extra input byte is read only to
+    determine whether the source was truncated.
+    """
+
+    with path.open("rb") as source_file:
+        raw_source = source_file.read(max_bytes + 1)
+
+    input_truncated = len(raw_source) > max_bytes
+    raw_source = raw_source[:max_bytes]
+    try:
+        encoding, _ = tokenize.detect_encoding(io.BytesIO(raw_source).readline)
+    except SyntaxError:
+        if not input_truncated:
+            raise
+        # A bounded read can split a UTF-8 code point on a very long first
+        # line. In that case the default Python source encoding still applies.
+        encoding = "utf-8"
+
+    source = raw_source.decode(
+        encoding,
+        errors="ignore" if input_truncated else "strict",
+    )
+    utf8_source = source.encode("utf-8")
+    output_truncated = len(utf8_source) > max_bytes
+    if output_truncated:
+        source = utf8_source[:max_bytes].decode("utf-8", errors="ignore")
+
+    return source, input_truncated or output_truncated
+
+
+def _collect_local_source_bundle(
+    entrypoint: Path,
+) -> Tuple[List[Dict[str, Any]], bool]:
     """Collect a bounded, dependency-aware source bundle for one MCP server.
 
     Registry paths are trusted, but import resolution is constrained to the
@@ -239,47 +277,72 @@ def collect_local_source_files(entrypoint: Path) -> List[Dict[str, Any]]:
     """
 
     root = entrypoint.parent.resolve()
-    entrypoint = _resolved_source_file(entrypoint, root)
-    if entrypoint is None:
-        return []
-    pending = [entrypoint]
+    resolved_entrypoint = _resolved_source_file(entrypoint, root)
+    if resolved_entrypoint is None:
+        return [], False
+    pending = [resolved_entrypoint]
     seen = set()
-    files: List[Dict[str, str]] = []
-    total_chars = 0
-    while pending and len(files) < MAX_LOCAL_SOURCE_FILES:
-        path = pending.pop(0)
-        path = _resolved_source_file(path, root)
-        if path is None or path in seen:
+    files: List[Dict[str, Any]] = []
+    total_bytes = 0
+    complete = True
+    while pending:
+        if len(files) >= MAX_LOCAL_SOURCE_FILES:
+            complete = False
+            break
+        remaining = MAX_LOCAL_SOURCE_BYTES - total_bytes
+        if remaining <= 0:
+            complete = False
+            break
+
+        candidate = pending.pop(0)
+        path = _resolved_source_file(candidate, root)
+        if path is None:
+            complete = False
+            continue
+        if path in seen:
             continue
         seen.add(path)
-        source = path.read_text(encoding="utf-8")
-        remaining = MAX_LOCAL_SOURCE_CHARS - total_chars
-        if remaining <= 0:
-            break
-        truncated = len(source) > remaining
-        included = source[:remaining]
-        files.append({
-            "path": str(path.relative_to(root)),
-            "source_code": included,
-            "truncated": truncated,
-        })
-        total_chars += len(included)
+
+        try:
+            included, truncated = _read_bounded_python_source(path, remaining)
+        except (LookupError, OSError, SyntaxError, UnicodeError) as exc:
+            logger.warning("Unable to include Python source %s: %s", path, exc)
+            complete = False
+            continue
+
+        files.append(
+            {
+                "path": str(path.relative_to(root)),
+                "source_code": included,
+                "truncated": truncated,
+            }
+        )
+        total_bytes += len(included.encode("utf-8"))
         if truncated:
+            complete = False
             break
         try:
-            tree = ast.parse(source, filename=str(path))
+            tree = ast.parse(included, filename=str(path))
         except (SyntaxError, ValueError):
             continue
         for node in ast.walk(tree):
             for dependency in _local_import_candidates(path, node, root):
                 if dependency not in seen and dependency not in pending:
                     pending.append(dependency)
+    return files, complete
+
+
+def collect_local_source_files(entrypoint: Path) -> List[Dict[str, Any]]:
+    """Return the source files from the bounded local dependency bundle."""
+
+    files, _ = _collect_local_source_bundle(entrypoint)
     return files
+
 
 @mcp.tool()
 def get_source_code(server_names: List[str]) -> Dict[str, Any]:
     """Get the source code of MCP servers for analysis"""
-    source_codes = []
+    source_codes: List[Dict[str, Any]] = []
 
     for server_name in server_names:
         # Find server in registry
@@ -304,9 +367,11 @@ def get_source_code(server_names: List[str]) -> Dict[str, Any]:
         try:
             resolved_path = _resolved_source_file(full_path, provider_root)
             if resolved_path is not None:
-                with open(resolved_path, 'r') as f:
+                with tokenize.open(resolved_path) as f:
                     source_code = f.read()
-                source_files = collect_local_source_files(resolved_path)
+                source_files, source_bundle_complete = _collect_local_source_bundle(
+                    resolved_path
+                )
 
                 # Provide clean metadata without cheating indicators
                 source_codes.append({
@@ -322,9 +387,7 @@ def get_source_code(server_names: List[str]) -> Dict[str, Any]:
                     "source_code": source_code,
                     "entrypoint": resolved_path.name,
                     "source_files": source_files,
-                    "source_bundle_complete": not any(
-                        item["truncated"] for item in source_files
-                    ),
+                    "source_bundle_complete": source_bundle_complete,
                 })
             else:
                 source_codes.append({

--- a/Detection/context_providers/source_code_analyzer_server.py
+++ b/Detection/context_providers/source_code_analyzer_server.py
@@ -256,6 +256,13 @@ def _decode_bounded_python_source(raw_source: bytes, max_bytes: int) -> Tuple[st
         return line
 
     encoding, _ = tokenize.detect_encoding(readline)
+    # bytes.decode rejects non-text codecs with LookupError. Use a nonempty
+    # probe because decoding empty bytes can bypass codec validation.
+    try:
+        b"\x00".decode(encoding)
+    except UnicodeError:
+        # A valid text codec may require more than one byte (e.g. UTF-16).
+        pass
     source = codecs.getincrementaldecoder(encoding)().decode(
         raw_source, final=not input_truncated
     )

--- a/Detection/context_providers/source_code_analyzer_server.py
+++ b/Detection/context_providers/source_code_analyzer_server.py
@@ -6,6 +6,7 @@ Provides MCP server source code for reasoning-based threat analysis.
 No pre-analysis or cheating metadata - just clean source code and basic info.
 """
 import ast
+import codecs
 import io
 import logging
 import os
@@ -232,36 +233,38 @@ def _local_import_candidates(current: Path, node: ast.AST, root: Path) -> List[P
     return candidates
 
 
-def _read_bounded_python_source(path: Path, max_bytes: int) -> Tuple[str, bool]:
-    """Read at most ``max_bytes`` of Python source, honoring its encoding.
+def _decode_bounded_python_source(raw_source: bytes, max_bytes: int) -> Tuple[str, bool]:
+    """Decode a bounded Python source prefix without discarding invalid bytes.
 
     The returned text is also bounded by its UTF-8 encoded size because that is
-    the representation sent to the model. One extra input byte is read only to
-    determine whether the source was truncated.
+    the representation sent to the model. The caller supplies at most one
+    extra input byte to determine whether the source was truncated.
     """
-
-    with path.open("rb") as source_file:
-        raw_source = source_file.read(max_bytes + 1)
 
     input_truncated = len(raw_source) > max_bytes
     raw_source = raw_source[:max_bytes]
-    try:
-        encoding, _ = tokenize.detect_encoding(io.BytesIO(raw_source).readline)
-    except SyntaxError:
-        if not input_truncated:
-            raise
-        # A bounded read can split a UTF-8 code point on a very long first
-        # line. In that case the default Python source encoding still applies.
-        encoding = "utf-8"
+    header = io.BytesIO(raw_source)
 
-    source = raw_source.decode(
-        encoding,
-        errors="ignore" if input_truncated else "strict",
+    def readline() -> bytes:
+        line = header.readline()
+        if input_truncated and line and not line.endswith(b"\n"):
+            # detect_encoding validates header lines as UTF-8. Permit a split
+            # trailing character, but still reject invalid interior bytes.
+            line = codecs.getincrementaldecoder("utf-8")().decode(
+                line, final=False
+            ).encode("utf-8")
+        return line
+
+    encoding, _ = tokenize.detect_encoding(readline)
+    source = codecs.getincrementaldecoder(encoding)().decode(
+        raw_source, final=not input_truncated
     )
     utf8_source = source.encode("utf-8")
     output_truncated = len(utf8_source) > max_bytes
     if output_truncated:
-        source = utf8_source[:max_bytes].decode("utf-8", errors="ignore")
+        source = codecs.getincrementaldecoder("utf-8")().decode(
+            utf8_source[:max_bytes], final=False
+        )
 
     return source, input_truncated or output_truncated
 
@@ -284,12 +287,13 @@ def _collect_local_source_bundle(
     seen = set()
     files: List[Dict[str, Any]] = []
     total_bytes = 0
+    total_read_bytes = 0
     complete = True
     while pending:
-        if len(files) >= MAX_LOCAL_SOURCE_FILES:
+        if len(seen) >= MAX_LOCAL_SOURCE_FILES:
             complete = False
             break
-        remaining = MAX_LOCAL_SOURCE_BYTES - total_bytes
+        remaining = MAX_LOCAL_SOURCE_BYTES - max(total_bytes, total_read_bytes)
         if remaining <= 0:
             complete = False
             break
@@ -304,8 +308,20 @@ def _collect_local_source_bundle(
         seen.add(path)
 
         try:
-            included, truncated = _read_bounded_python_source(path, remaining)
-        except (LookupError, OSError, SyntaxError, UnicodeError) as exc:
+            with path.open("rb") as source_file:
+                raw_source = source_file.read(remaining + 1)
+        except OSError as exc:
+            # A failed read may have consumed input before raising. Conservatively
+            # stop rather than retrying other files with an uncharged budget.
+            logger.warning("Unable to read Python source %s: %s", path, exc)
+            complete = False
+            break
+        # Charge input even when decoding fails. Each attempted file permits
+        # one additional lookahead byte solely for detecting truncation.
+        total_read_bytes += min(len(raw_source), remaining)
+        try:
+            included, truncated = _decode_bounded_python_source(raw_source, remaining)
+        except (LookupError, SyntaxError, UnicodeError) as exc:
             logger.warning("Unable to include Python source %s: %s", path, exc)
             complete = False
             continue

--- a/Detection/tests/test_source_code_analyzer_server.py
+++ b/Detection/tests/test_source_code_analyzer_server.py
@@ -1,0 +1,197 @@
+"""Tests for dependency-aware source retrieval."""
+
+import inspect
+from importlib.machinery import EXTENSION_SUFFIXES
+
+from context_providers import source_code_analyzer_server as analyzer
+from context_providers.source_code_analyzer_server import collect_local_source_files
+
+
+def test_collects_local_imported_implementation_without_unrelated_files(tmp_path):
+    function_dir = tmp_path / "function"
+    function_dir.mkdir()
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text(
+        "from function.core import run\n\ndef tool():\n    return run()\n",
+        encoding="utf-8",
+    )
+    (function_dir / "core.py").write_text(
+        "def run():\n    return 'hidden implementation'\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "unrelated.py").write_text("SECRET = True\n", encoding="utf-8")
+
+    files = collect_local_source_files(entrypoint)
+    by_path = {item["path"]: item for item in files}
+    assert set(by_path) == {"server.py", "function/core.py"}
+    assert "hidden implementation" in by_path["function/core.py"]["source_code"]
+    assert all(str(tmp_path) not in item["path"] for item in files)
+
+
+def test_relative_imports_remain_inside_server_root(tmp_path):
+    package = tmp_path / "package"
+    package.mkdir()
+    entrypoint = package / "entry.py"
+    entrypoint.write_text("from .helper import value\n", encoding="utf-8")
+    (package / "helper.py").write_text("value = 1\n", encoding="utf-8")
+
+    files = collect_local_source_files(entrypoint)
+    assert {item["path"] for item in files} == {"entry.py", "helper.py"}
+
+
+def test_regular_package_precedes_same_named_module(tmp_path):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import dependency\n", encoding="utf-8")
+    (tmp_path / "dependency.py").write_text("KIND = 'module'\n", encoding="utf-8")
+    package = tmp_path / "dependency"
+    package.mkdir()
+    (package / "__init__.py").write_text("KIND = 'package'\n", encoding="utf-8")
+
+    files = collect_local_source_files(entrypoint)
+    by_path = {item["path"]: item for item in files}
+
+    assert set(by_path) == {"server.py", "dependency/__init__.py"}
+    assert "KIND = 'package'" in by_path["dependency/__init__.py"]["source_code"]
+
+
+def test_namespace_package_does_not_shadow_same_named_module(tmp_path):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import dependency\n", encoding="utf-8")
+    (tmp_path / "dependency.py").write_text("KIND = 'module'\n", encoding="utf-8")
+    (tmp_path / "dependency").mkdir()
+
+    files = collect_local_source_files(entrypoint)
+
+    assert {item["path"] for item in files} == {"server.py", "dependency.py"}
+
+
+def test_from_package_import_follows_initializer_and_submodule(tmp_path):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("from dependency import implementation\n", encoding="utf-8")
+    package = tmp_path / "dependency"
+    package.mkdir()
+    (package / "__init__.py").write_text("PACKAGE = True\n", encoding="utf-8")
+    (package / "implementation.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    files = collect_local_source_files(entrypoint)
+
+    assert {item["path"] for item in files} == {
+        "server.py",
+        "dependency/__init__.py",
+        "dependency/implementation.py",
+    }
+
+
+def test_builtin_module_precedes_same_named_local_source(tmp_path):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import sys\n", encoding="utf-8")
+    (tmp_path / "sys.py").write_text("LOCAL = True\n", encoding="utf-8")
+
+    files = collect_local_source_files(entrypoint)
+
+    assert {item["path"] for item in files} == {"server.py"}
+
+
+def test_native_module_precedes_same_named_local_source(tmp_path):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import dependency\n", encoding="utf-8")
+    (tmp_path / "dependency.py").write_text("LOCAL = True\n", encoding="utf-8")
+    (tmp_path / f"dependency{EXTENSION_SUFFIXES[0]}").write_bytes(b"")
+
+    files = collect_local_source_files(entrypoint)
+
+    assert {item["path"] for item in files} == {"server.py"}
+
+
+def test_source_discovery_never_executes_imported_module(tmp_path):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import dependency\n", encoding="utf-8")
+    marker = tmp_path / "executed"
+    (tmp_path / "dependency.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).touch()\n",
+        encoding="utf-8",
+    )
+
+    files = collect_local_source_files(entrypoint)
+
+    assert {item["path"] for item in files} == {"server.py", "dependency.py"}
+    assert not marker.exists()
+
+
+def test_symlinked_import_is_not_returned_as_local_source(tmp_path):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import linked\n", encoding="utf-8")
+    implementation = tmp_path / "implementation.py"
+    implementation.write_text("VALUE = 1\n", encoding="utf-8")
+    (tmp_path / "linked.py").symlink_to(implementation)
+
+    files = collect_local_source_files(entrypoint)
+
+    assert {item["path"] for item in files} == {"server.py"}
+
+
+def test_registry_entrypoint_cannot_escape_provider_root(tmp_path, monkeypatch):
+    provider_root = tmp_path / "provider"
+    provider_root.mkdir()
+    secret = tmp_path / "secret.py"
+    secret.write_text("SECRET = 'must not be returned'\n", encoding="utf-8")
+    monkeypatch.setattr(analyzer, "__file__", str(provider_root / "provider.py"))
+    monkeypatch.setattr(
+        analyzer,
+        "source_registry",
+        {"mcp_servers": [{"name": "escaped", "path": "../secret.py"}]},
+    )
+
+    result = analyzer.get_source_code(["escaped"])
+
+    assert result == {
+        "source_codes": [{"server_name": "escaped", "status": "file_not_found"}],
+        "total_retrieved": 0,
+    }
+
+
+def test_benchmark_public_contract_is_unchanged(tmp_path, monkeypatch):
+    provider_root = tmp_path / "provider"
+    provider_root.mkdir()
+    entrypoint = provider_root / "server.py"
+    entrypoint.write_text("import dependency\n", encoding="utf-8")
+    (provider_root / "dependency.py").write_text("VALUE = 1\n", encoding="utf-8")
+    monkeypatch.setattr(analyzer, "__file__", str(provider_root / "provider.py"))
+    monkeypatch.setattr(
+        analyzer,
+        "source_registry",
+        {
+            "mcp_servers": [
+                {
+                    "name": "example",
+                    "path": "server.py",
+                    "category": "test",
+                    "description": "example server",
+                    "capabilities": ["read"],
+                }
+            ]
+        },
+    )
+
+    result = analyzer.get_source_code(["example"])
+    row = result["source_codes"][0]
+
+    assert set(result) == {"source_codes", "total_retrieved"}
+    assert set(row) == {
+        "server_name",
+        "status",
+        "metadata",
+        "source_code",
+        "entrypoint",
+        "source_files",
+        "source_bundle_complete",
+    }
+    assert all(
+        set(source_file) == {"path", "source_code", "truncated"}
+        for source_file in row["source_files"]
+    )
+    assert list(inspect.signature(collect_local_source_files).parameters) == [
+        "entrypoint"
+    ]
+    assert analyzer.MAX_LOCAL_SOURCE_FILES == 24
+    assert analyzer.MAX_LOCAL_SOURCE_CHARS == 240_000

--- a/Detection/tests/test_source_code_analyzer_server.py
+++ b/Detection/tests/test_source_code_analyzer_server.py
@@ -372,3 +372,24 @@ def test_decode_failure_keeps_later_dependency_when_budget_remains(tmp_path, mon
     assert row["status"] == "found"
     assert [item["path"] for item in row["source_files"]] == ["server.py", "good.py"]
     assert row["source_bundle_complete"] is False
+
+
+@pytest.mark.parametrize("encoding", ["rot_13", "base64_codec", "hex_codec"])
+def test_non_text_codec_preserves_entrypoint_and_other_dependencies(
+    tmp_path, monkeypatch, encoding
+):
+    entrypoint = tmp_path / "server.py"
+    entry_source = "import bad, good\n"
+    entrypoint.write_text(entry_source, encoding="utf-8")
+    (tmp_path / "bad.py").write_text(
+        f"# coding: {encoding}\nVALUE = 1\n", encoding="utf-8"
+    )
+    (tmp_path / "good.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    row = _get_registered_source(monkeypatch, tmp_path, entrypoint)
+
+    assert row["status"] == "found"
+    assert row["source_code"] == entry_source
+    assert [item["path"] for item in row["source_files"]] == ["server.py", "good.py"]
+    assert row["source_files"][1]["source_code"] == "VALUE = 2\n"
+    assert row["source_bundle_complete"] is False

--- a/Detection/tests/test_source_code_analyzer_server.py
+++ b/Detection/tests/test_source_code_analyzer_server.py
@@ -7,6 +7,26 @@ from context_providers import source_code_analyzer_server as analyzer
 from context_providers.source_code_analyzer_server import collect_local_source_files
 
 
+def _get_registered_source(monkeypatch, provider_root, entrypoint):
+    monkeypatch.setattr(analyzer, "__file__", str(provider_root / "provider.py"))
+    monkeypatch.setattr(
+        analyzer,
+        "source_registry",
+        {
+            "mcp_servers": [
+                {
+                    "name": "example",
+                    "path": str(entrypoint.relative_to(provider_root)),
+                    "category": "test",
+                    "description": "example server",
+                    "capabilities": ["read"],
+                }
+            ]
+        },
+    )
+    return analyzer.get_source_code(["example"])["source_codes"][0]
+
+
 def test_collects_local_imported_implementation_without_unrelated_files(tmp_path):
     function_dir = tmp_path / "function"
     function_dir.mkdir()
@@ -150,6 +170,65 @@ def test_registry_entrypoint_cannot_escape_provider_root(tmp_path, monkeypatch):
     }
 
 
+def test_file_limit_marks_bundle_incomplete_when_dependencies_remain(tmp_path, monkeypatch):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text(
+        "\n".join(f"import dependency_{index}" for index in range(analyzer.MAX_LOCAL_SOURCE_FILES)),
+        encoding="utf-8",
+    )
+    for index in range(analyzer.MAX_LOCAL_SOURCE_FILES):
+        (tmp_path / f"dependency_{index}.py").write_text(f"VALUE = {index}\n", encoding="utf-8")
+
+    row = _get_registered_source(monkeypatch, tmp_path, entrypoint)
+
+    assert len(row["source_files"]) == analyzer.MAX_LOCAL_SOURCE_FILES
+    assert not any(item["truncated"] for item in row["source_files"])
+    assert row["source_bundle_complete"] is False
+
+
+def test_exact_byte_limit_marks_bundle_incomplete_when_dependency_remains(tmp_path, monkeypatch):
+    entrypoint = tmp_path / "server.py"
+    entrypoint_source = "import dependency\n"
+    entrypoint.write_text(entrypoint_source, encoding="utf-8")
+    (tmp_path / "dependency.py").write_text("VALUE = 1\n", encoding="utf-8")
+    monkeypatch.setattr(analyzer, "MAX_LOCAL_SOURCE_BYTES", len(entrypoint_source.encode("utf-8")))
+
+    row = _get_registered_source(monkeypatch, tmp_path, entrypoint)
+
+    assert [item["path"] for item in row["source_files"]] == ["server.py"]
+    assert row["source_files"][0]["truncated"] is False
+    assert row["source_bundle_complete"] is False
+
+
+def test_source_bundle_limit_counts_utf8_bytes(tmp_path, monkeypatch):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import dependency\n", encoding="utf-8")
+    (tmp_path / "dependency.py").write_text(f"VALUE = {'😀' * 100!r}\n", encoding="utf-8")
+    byte_limit = 128
+    monkeypatch.setattr(analyzer, "MAX_LOCAL_SOURCE_BYTES", byte_limit)
+
+    row = _get_registered_source(monkeypatch, tmp_path, entrypoint)
+
+    assert (
+        sum(len(item["source_code"].encode("utf-8")) for item in row["source_files"]) <= byte_limit
+    )
+    assert row["source_files"][-1]["truncated"] is True
+    assert row["source_bundle_complete"] is False
+
+
+def test_valid_non_utf8_dependency_does_not_fail_server_response(tmp_path, monkeypatch):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import dependency\n", encoding="utf-8")
+    (tmp_path / "dependency.py").write_bytes(b"# -*- coding: latin-1 -*-\nVALUE = 'caf\xe9'\n")
+
+    row = _get_registered_source(monkeypatch, tmp_path, entrypoint)
+    source_by_path = {item["path"]: item["source_code"] for item in row["source_files"]}
+
+    assert row["status"] == "found"
+    assert row["source_bundle_complete"] is True
+    assert "café" in source_by_path["dependency.py"]
+
+
 def test_benchmark_public_contract_is_unchanged(tmp_path, monkeypatch):
     provider_root = tmp_path / "provider"
     provider_root.mkdir()
@@ -190,8 +269,6 @@ def test_benchmark_public_contract_is_unchanged(tmp_path, monkeypatch):
         set(source_file) == {"path", "source_code", "truncated"}
         for source_file in row["source_files"]
     )
-    assert list(inspect.signature(collect_local_source_files).parameters) == [
-        "entrypoint"
-    ]
+    assert list(inspect.signature(collect_local_source_files).parameters) == ["entrypoint"]
     assert analyzer.MAX_LOCAL_SOURCE_FILES == 24
-    assert analyzer.MAX_LOCAL_SOURCE_CHARS == 240_000
+    assert analyzer.MAX_LOCAL_SOURCE_BYTES == 240_000

--- a/Detection/tests/test_source_code_analyzer_server.py
+++ b/Detection/tests/test_source_code_analyzer_server.py
@@ -2,6 +2,9 @@
 
 import inspect
 from importlib.machinery import EXTENSION_SUFFIXES
+from pathlib import Path
+
+import pytest
 
 from context_providers import source_code_analyzer_server as analyzer
 from context_providers.source_code_analyzer_server import collect_local_source_files
@@ -272,3 +275,100 @@ def test_benchmark_public_contract_is_unchanged(tmp_path, monkeypatch):
     assert list(inspect.signature(collect_local_source_files).parameters) == ["entrypoint"]
     assert analyzer.MAX_LOCAL_SOURCE_FILES == 24
     assert analyzer.MAX_LOCAL_SOURCE_BYTES == 240_000
+
+
+def _record_binary_reads(monkeypatch):
+    opened = []
+    original_open = Path.open
+
+    def recording_open(path, mode="r", *args, **kwargs):
+        if mode == "rb":
+            opened.append(path.name)
+        return original_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", recording_open)
+    return opened
+
+
+def test_failed_decodes_count_toward_file_limit(tmp_path, monkeypatch):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import bad0, bad1, bad2, bad3\n", encoding="utf-8")
+    for index in range(4):
+        (tmp_path / f"bad{index}.py").write_bytes(b"# coding: ascii\nVALUE = '\xff'\n")
+    monkeypatch.setattr(analyzer, "MAX_LOCAL_SOURCE_FILES", 3)
+    opened = _record_binary_reads(monkeypatch)
+
+    files, complete = analyzer._collect_local_source_bundle(entrypoint)
+
+    assert opened == ["server.py", "bad0.py", "bad1.py"]
+    assert [item["path"] for item in files] == ["server.py"]
+    assert complete is False
+
+
+def test_failed_decode_consumes_read_budget(tmp_path, monkeypatch):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import bad, good\n", encoding="utf-8")
+    (tmp_path / "bad.py").write_bytes(b"# coding: ascii\n" + b"\xff" * 200)
+    (tmp_path / "good.py").write_text("VALUE = 1\n", encoding="utf-8")
+    monkeypatch.setattr(analyzer, "MAX_LOCAL_SOURCE_BYTES", 96)
+    opened = _record_binary_reads(monkeypatch)
+
+    files, complete = analyzer._collect_local_source_bundle(entrypoint)
+
+    assert opened == ["server.py", "bad.py"]
+    assert [item["path"] for item in files] == ["server.py"]
+    assert complete is False
+
+
+@pytest.mark.parametrize("prefix", [
+    b"VALUE = 'se\xffcret'\n",
+    b"# coding: ascii\nVALUE = 'se\xffcret'\n",
+    b"# coding: not_a_codec\nVALUE = 1\n",
+])
+def test_truncated_invalid_source_is_not_silently_rewritten(tmp_path, monkeypatch, prefix):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import dependency\n", encoding="utf-8")
+    (tmp_path / "dependency.py").write_bytes(prefix + b"#" * 200)
+    monkeypatch.setattr(analyzer, "MAX_LOCAL_SOURCE_BYTES", 96)
+
+    row = _get_registered_source(monkeypatch, tmp_path, entrypoint)
+
+    assert row["status"] == "found"
+    assert row["source_code"] == "import dependency\n"
+    assert [item["path"] for item in row["source_files"]] == ["server.py"]
+    assert row["source_bundle_complete"] is False
+
+
+@pytest.mark.parametrize("encoding,header", [
+    ("utf-8", ""),
+    ("utf-8", "# coding: utf-8\n"),
+    ("shift_jis", "# coding: shift_jis\n"),
+])
+def test_split_trailing_character_preserves_valid_prefix(tmp_path, monkeypatch, encoding, header):
+    entrypoint = tmp_path / "server.py"
+    entry_source = "import dependency\n"
+    entrypoint.write_text(entry_source, encoding="utf-8")
+    prefix = header + "VALUE = '"
+    (tmp_path / "dependency.py").write_bytes((prefix + "日'\n").encode(encoding))
+    # Include the first byte of a multibyte character at the input boundary.
+    limit = len(entry_source.encode()) + len(prefix.encode(encoding)) + 1
+    monkeypatch.setattr(analyzer, "MAX_LOCAL_SOURCE_BYTES", limit)
+
+    row = _get_registered_source(monkeypatch, tmp_path, entrypoint)
+
+    assert row["source_files"][-1]["source_code"] == prefix
+    assert row["source_files"][-1]["truncated"] is True
+    assert row["source_bundle_complete"] is False
+
+
+def test_decode_failure_keeps_later_dependency_when_budget_remains(tmp_path, monkeypatch):
+    entrypoint = tmp_path / "server.py"
+    entrypoint.write_text("import bad, good\n", encoding="utf-8")
+    (tmp_path / "bad.py").write_bytes(b"\xff")
+    (tmp_path / "good.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    row = _get_registered_source(monkeypatch, tmp_path, entrypoint)
+
+    assert row["status"] == "found"
+    assert [item["path"] for item in row["source_files"]] == ["server.py", "good.py"]
+    assert row["source_bundle_complete"] is False


### PR DESCRIPTION
**Related issue**:

Relates to https://github.com/uber/ADR/issues/50

**What changed?**

`get_source_code` now returns a bounded, dependency-aware source bundle for
registered Python MCP servers instead of exposing only the registered
entrypoint.

The implementation:

- statically follows local `import` and `from ... import ...` statements;
- includes package initializers and imported implementation modules;
- handles relative imports and namespace packages;
- follows Python package-versus-module and built-in/frozen/native-loader
  precedence;
- constrains resolved paths to the registered server directory;
- excludes symlinked source candidates;
- deduplicates cycles and preserves deterministic discovery order;
- never imports or executes discovered modules; and
- preserves the existing `source_code` entrypoint field and MCP input schema.

The additional source is returned through `source_files`, with
`source_bundle_complete` indicating whether the bounded bundle was truncated.

No detector prompts, routing rules, model configuration, or verdict semantics
are changed.

**How did you test it?**

Deterministic tests cover:

- local and relative imports;
- package initializers and `from package import submodule`;
- regular-package versus same-named-module precedence;
- namespace-package behavior;
- built-in and native-module precedence;
- cycles and unrelated-file exclusion;
- resolved-path containment and registry traversal attempts;
- symlink exclusion;
- confirmation that discovered modules are never executed; and
- preservation of the existing MCP schema and response shape.

Local results:

- Python 3.11 focused provider/baseline suite: 74 passed
- Python 3.12 focused provider/baseline suite: 74 passed
- Full Detection suite: 129 passed
- Registry smoke test: 115/115 registered sources retrieved

We also ran an isolated three-repeat ADR-Bench development comparison with
stock Tier 1 and Tier 2 behavior. The only changed variable was entrypoint-only
versus import-following source context. A second control removed comments and
docstrings while retaining executable code.

| Source control | Metric | Entrypoint only | Imports |
|---|---|---:|---:|
| Raw source | Mean recall | 77.8% | 82.5% |
| Raw source | Mean FPR | 13.5% | 12.9% |
| Comments/docstrings stripped | Mean recall | 77.8% | 84.1% |
| Comments/docstrings stripped | Mean FPR | 15.1% | 15.3% |

`task_008` was consistently recovered by import-following retrieval in all
three raw-source and all three comments/docstrings-stripped repeats. The
entrypoint-only arm classified it as benign in all six corresponding runs.

The imported implementation exposed executable behavior in
`function/ai_insights.py` and `function/system_analyzer.py`, including encoded
session-token handling, decoding, endpoint modification, and silent
exfiltration. The result persisted after comments and docstrings were removed,
indicating that the recovery came from executable implementation behavior
rather than vulnerability-describing prose.
