### PR TITLE
fix(sensor): honor CLI display limit

### DIFF
--- a/Sensor/adr_sensor/cli.py
+++ b/Sensor/adr_sensor/cli.py
@@ -31,6 +31,14 @@ def get_version():
     return __version__
 
 
+def _non_negative_int(value: str) -> int:
+    """Parse a non-negative integer for bounded display options."""
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be zero or greater")
+    return parsed
+
+
 def main():
     """Main entry point for the ADR Sensor CLI."""
     parser = argparse.ArgumentParser(
@@ -72,7 +80,7 @@ Examples:
         default=None,
         help="Directory to save output files (default: ./output)",
     )
-    parser.add_argument("--limit", type=int, default=2, help="Number of entries to display")
+    parser.add_argument("--limit", type=_non_negative_int, default=2, help="Number of entries to display")
     parser.add_argument("--no-save", action="store_true", help="Do not save to file")
     parser.add_argument(
         "--save-sessions",
@@ -123,7 +131,7 @@ Examples:
             print(f"  -> Filtered {original_count - filtered_count} existing sessions, processing {filtered_count} new")
 
         # Display summary
-        observer.display_summary(entries, system_config_data)
+        observer.display_summary(entries, system_config_data, limit=args.limit)
 
         # Save
         if entries or system_config_data:

--- a/Sensor/adr_sensor/observer.py
+++ b/Sensor/adr_sensor/observer.py
@@ -155,9 +155,12 @@ class AgentObserver:
         return all_entries, system_config_data
 
     def display_summary(
-        self, entries: List[AgentEvent], system_config_data: List[SystemConfiguration]
+        self,
+        entries: List[AgentEvent],
+        system_config_data: List[SystemConfiguration],
+        limit: int = 2,
     ) -> None:
-        """Display a summary of ingested logs."""
+        """Display aggregate counts and a bounded preview of recent entries."""
         if not entries and not system_config_data:
             print("No logs found!")
             return
@@ -195,6 +198,12 @@ class AgentObserver:
             )
         )
         print()
+
+        if entries and limit > 0:
+            print("RECENT ENTRIES")
+            for entry in sorted(entries, key=lambda item: normalize_timestamp(item.timestamp), reverse=True)[:limit]:
+                print(f"  {entry.get_summary()}")
+            print()
 
     def save_to_file(
         self,

--- a/Sensor/tests/test_cli.py
+++ b/Sensor/tests/test_cli.py
@@ -1,7 +1,32 @@
+import argparse
+import sys
 from importlib.metadata import version
+from unittest.mock import patch
 
-from adr_sensor.cli import get_version
+import pytest
+
+from adr_sensor.cli import _non_negative_int, get_version, main
 
 
 def test_cli_version_matches_package_metadata():
     assert get_version() == version("adr-sensor")
+
+
+def test_non_negative_int_rejects_negative_limits():
+    with pytest.raises(argparse.ArgumentTypeError, match="zero or greater"):
+        _non_negative_int("-1")
+
+
+def test_non_negative_int_accepts_zero():
+    assert _non_negative_int("0") == 0
+
+
+@patch("adr_sensor.cli.AgentObserver")
+def test_cli_passes_display_limit_to_observer(mock_observer_class, monkeypatch):
+    observer = mock_observer_class.return_value
+    observer.ingest_all.return_value = ([], [])
+    monkeypatch.setattr(sys, "argv", ["adr-sensor", "--limit", "7", "--no-save"])
+
+    main()
+
+    observer.display_summary.assert_called_once_with([], [], limit=7)

--- a/Sensor/tests/test_observer.py
+++ b/Sensor/tests/test_observer.py
@@ -2,13 +2,10 @@
 
 import json
 from datetime import datetime, timezone
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from adr_sensor.observer import AgentObserver
-from adr_sensor.schemas.agent_event_schema import AgentEvent, ChatMessage, ToolUsage
+from adr_sensor.schemas.agent_event_schema import AgentEvent, ChatMessage
 
 
 class TestAgentObserver:
@@ -44,6 +41,45 @@ class TestAgentObserver:
         captured = capsys.readouterr()
         assert "CLAUDE" in captured.out
         assert "INGESTION SUMMARY" in captured.out
+
+    def test_display_summary_limits_recent_entries(self, tmp_path, capsys):
+        observer = AgentObserver(output_dir=tmp_path)
+        entries = [
+            AgentEvent(
+                timestamp=datetime(2025, 1, day, tzinfo=timezone.utc),
+                source="claude",
+                session_id=f"session-{day}",
+                hostname="host",
+                username="user",
+                chat_history=[ChatMessage(role="user", content="hello")],
+            )
+            for day in (1, 2, 3)
+        ]
+
+        observer.display_summary(entries, [], limit=2)
+
+        output = capsys.readouterr().out
+        assert "RECENT ENTRIES" in output
+        assert "2025-01-03" in output
+        assert "2025-01-02" in output
+        assert "2025-01-01" not in output
+
+    def test_display_summary_zero_limit_hides_entries(self, tmp_path, capsys):
+        observer = AgentObserver(output_dir=tmp_path)
+        entry = AgentEvent(
+            timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            source="claude",
+            session_id="session-1",
+            hostname="host",
+            username="user",
+            chat_history=[ChatMessage(role="user", content="hello")],
+        )
+
+        observer.display_summary([entry], [], limit=0)
+
+        output = capsys.readouterr().out
+        assert "INGESTION SUMMARY" in output
+        assert "RECENT ENTRIES" not in output
 
     def test_save_to_file_json(self, tmp_path):
         """Test saving entries as JSON."""


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**Related issue**: Closes #118

**What changed?**

- Pass the parsed `--limit` value into `AgentObserver.display_summary()`.
- Print a newest-first, bounded preview using the existing `AgentEvent.get_summary()` representation.
- Treat `--limit 0` as disabling the preview and reject negative values during argument parsing.
- Add CLI wiring, validation, ordering, and limit regression tests.

**Why?**

The CLI advertised `--limit` as controlling the number of displayed entries, but the value was never consumed. Every value therefore produced the same aggregate-only output.

**How did you test it?**

- `.venv/bin/pytest -q` — 128 passed
- `.venv/bin/ruff check adr_sensor/`
- Ruff checks on the changed test files
- `git diff --check`

**Potential risks**

Low. The default CLI output now includes the two entry summaries the existing default limit promised. API callers can pass `limit=0` to retain aggregate-only output. Entry ordering is newest first and normalizes naive timestamps as UTC through the existing timestamp utility.